### PR TITLE
deps: Switch osext's repo (bitbucket->github).

### DIFF
--- a/service_darwin.go
+++ b/service_darwin.go
@@ -13,7 +13,7 @@ import (
 	"text/template"
 	"time"
 
-	"bitbucket.org/kardianos/osext"
+	"github.com/kardianos/osext"
 )
 
 const maxPathSize = 32 * 1024

--- a/service_linux.go
+++ b/service_linux.go
@@ -14,7 +14,7 @@ import (
 	"text/template"
 	"time"
 
-	"bitbucket.org/kardianos/osext"
+	"github.com/kardianos/osext"
 )
 
 const (

--- a/service_windows.go
+++ b/service_windows.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 	"time"
 
-	"bitbucket.org/kardianos/osext"
+	"github.com/kardianos/osext"
 	"code.google.com/p/winsvc/eventlog"
 	"code.google.com/p/winsvc/mgr"
 	"code.google.com/p/winsvc/svc"


### PR DESCRIPTION
bitbucket repo is not up-to-date and can't be imported due to canonical import path (https://bitbucket.org/kardianos/osext/commits/816c96ec6fef6a0cd72c9395d192c4bd0d918753?at=default)