### PR TITLE
Add support for Windows Service dependencies

### DIFF
--- a/service.go
+++ b/service.go
@@ -18,7 +18,7 @@
 	import (
 		"log"
 
-		"github.com/nollan/service"
+		"github.com/kardianos/service"
 	)
 
 	var logger service.Logger
@@ -60,7 +60,7 @@
 		}
 	}
 */
-package service // import "github.com/nollan/service"
+package service // import "github.com/kardianos/service"
 
 import (
 	"errors"

--- a/service.go
+++ b/service.go
@@ -18,7 +18,7 @@
 	import (
 		"log"
 
-		"github.com/kardianos/service"
+		"github.com/nollan/service"
 	)
 
 	var logger service.Logger
@@ -60,7 +60,7 @@
 		}
 	}
 */
-package service // import "github.com/kardianos/service"
+package service // import "github.com/nollan/service"
 
 import (
 	"errors"
@@ -69,9 +69,10 @@ import (
 
 // Config provides the setup for a Service. The Name field is required.
 type Config struct {
-	Name        string // Required name of the service. No spaces suggested.
-	DisplayName string // Display name, spaces allowed.
-	Description string // Long description of service.
+	Name         string   // Required name of the service. No spaces suggested.
+	DisplayName  string   // Display name, spaces allowed.
+	Description  string   // Long description of service.
+	Dependencies []string // Array of service dependencies.
 
 	UserName  string   // Run as username.
 	Arguments []string // Run with arguments.

--- a/service_windows.go
+++ b/service_windows.go
@@ -195,6 +195,7 @@ func (ws *windowsService) Install() error {
 		StartType:        mgr.StartAutomatic,
 		ServiceStartName: ws.UserName,
 		Password:         ws.Option.string("Password", ""),
+		Dependencies:     ws.Dependencies,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
"Winsvc" is fixed so it can handle dependencies for Window Services: https://code.google.com/p/winsvc/issues/detail?id=10&can=1
My little change adds "Dependencies" field into the structs.