### PR TITLE
Run() should watch for SIGTERM on POSIX platforms

### DIFF
--- a/service_darwin.go
+++ b/service_darwin.go
@@ -173,7 +173,7 @@ func (s *darwinLaunchdService) Run() error {
 
 	var sigChan = make(chan os.Signal, 3)
 
-	signal.Notify(sigChan, syscall.SIGTERM, os.Interrupt, os.Kill)
+	signal.Notify(sigChan, syscall.SIGTERM, os.Interrupt)
 
 	<-sigChan
 

--- a/service_darwin.go
+++ b/service_darwin.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"os/user"
+	"syscall"
 	"text/template"
 	"time"
 
@@ -172,7 +173,7 @@ func (s *darwinLaunchdService) Run() error {
 
 	var sigChan = make(chan os.Signal, 3)
 
-	signal.Notify(sigChan, os.Interrupt, os.Kill)
+	signal.Notify(sigChan, syscall.SIGTERM, os.Interrupt, os.Kill)
 
 	<-sigChan
 

--- a/service_systemd_linux.go
+++ b/service_systemd_linux.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"syscall"
 	"text/template"
 	"time"
 
@@ -130,7 +131,7 @@ func (s *systemd) Run() (err error) {
 
 	sigChan := make(chan os.Signal, 3)
 
-	signal.Notify(sigChan, os.Interrupt, os.Kill)
+	signal.Notify(sigChan, syscall.SIGTERM, os.Interrupt, os.Kill)
 
 	<-sigChan
 

--- a/service_systemd_linux.go
+++ b/service_systemd_linux.go
@@ -131,7 +131,7 @@ func (s *systemd) Run() (err error) {
 
 	sigChan := make(chan os.Signal, 3)
 
-	signal.Notify(sigChan, syscall.SIGTERM, os.Interrupt, os.Kill)
+	signal.Notify(sigChan, syscall.SIGTERM, os.Interrupt)
 
 	<-sigChan
 

--- a/service_sysv_linux.go
+++ b/service_sysv_linux.go
@@ -132,7 +132,7 @@ func (s *sysv) Run() (err error) {
 
 	sigChan := make(chan os.Signal, 3)
 
-	signal.Notify(sigChan, syscall.SIGTERM, os.Interrupt, os.Kill)
+	signal.Notify(sigChan, syscall.SIGTERM, os.Interrupt)
 
 	<-sigChan
 

--- a/service_sysv_linux.go
+++ b/service_sysv_linux.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"syscall"
 	"text/template"
 	"time"
 
@@ -131,7 +132,7 @@ func (s *sysv) Run() (err error) {
 
 	sigChan := make(chan os.Signal, 3)
 
-	signal.Notify(sigChan, os.Interrupt, os.Kill)
+	signal.Notify(sigChan, syscall.SIGTERM, os.Interrupt, os.Kill)
 
 	<-sigChan
 

--- a/service_upstart_linux.go
+++ b/service_upstart_linux.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"syscall"
 	"text/template"
 	"time"
 
@@ -122,7 +123,7 @@ func (s *upstart) Run() (err error) {
 
 	sigChan := make(chan os.Signal, 3)
 
-	signal.Notify(sigChan, os.Interrupt, os.Kill)
+	signal.Notify(sigChan, syscall.SIGTERM, os.Interrupt, os.Kill)
 
 	<-sigChan
 

--- a/service_upstart_linux.go
+++ b/service_upstart_linux.go
@@ -123,7 +123,7 @@ func (s *upstart) Run() (err error) {
 
 	sigChan := make(chan os.Signal, 3)
 
-	signal.Notify(sigChan, syscall.SIGTERM, os.Interrupt, os.Kill)
+	signal.Notify(sigChan, syscall.SIGTERM, os.Interrupt)
 
 	<-sigChan
 


### PR DESCRIPTION
The tools used by Stop() send SIGTERM, not SIGINT, so Run() should handle that. (Note that watching os.Kill is meaningless; you can't respond to that signal. I left it in and it doesn't hurt anything, but it probably should come out to prevent confusion.)