### PR TITLE
Added SessionCreate set to true for OSX

### DIFF
--- a/service.go
+++ b/service.go
@@ -70,12 +70,14 @@ import (
 )
 
 const (
-	optionKeepAlive          = "KeepAlive"
-	optionKeepAliveDefault   = true
-	optionRunAtLoad          = "RunAtLoad"
-	optionRunAtLoadDefault   = false
-	optionUserService        = "UserService"
-	optionUserServiceDefault = false
+	optionKeepAlive            = "KeepAlive"
+	optionKeepAliveDefault     = true
+	optionRunAtLoad            = "RunAtLoad"
+	optionRunAtLoadDefault     = false
+	optionUserService          = "UserService"
+	optionUserServiceDefault   = false
+	optionSessionCreate        = "SessionCreate"
+	optionSessionCreateDefault = true
 )
 
 // Config provides the setup for a Service. The Name field is required.
@@ -103,6 +105,7 @@ type Config struct {
 	//    - KeepAlive   bool (true)
 	//    - RunAtLoad   bool (false)
 	//    - UserService bool (false) // Install as a current user service.
+	//    - SessionCreate bool (true)
 	Option KeyValue
 }
 

--- a/service_darwin.go
+++ b/service_darwin.go
@@ -118,12 +118,13 @@ func (s *darwinLaunchdService) Install() error {
 		*Config
 		Path string
 
-		KeepAlive, RunAtLoad bool
+		KeepAlive, RunAtLoad, SessionCreate bool
 	}{
-		Config:    s.Config,
-		Path:      path,
-		KeepAlive: s.Option.bool(optionKeepAlive, optionKeepAliveDefault),
-		RunAtLoad: s.Option.bool(optionRunAtLoad, optionRunAtLoadDefault),
+		Config:        s.Config,
+		Path:          path,
+		KeepAlive:     s.Option.bool(optionKeepAlive, optionKeepAliveDefault),
+		RunAtLoad:     s.Option.bool(optionRunAtLoad, optionRunAtLoadDefault),
+		SessionCreate: s.Option.bool(optionSessionCreate, optionSessionCreateDefault),
 	}
 
 	functions := template.FuncMap{
@@ -216,6 +217,7 @@ var launchdConfig = `<?xml version='1.0' encoding='UTF-8'?>
 {{if .WorkingDirectory}}<key>WorkingDirectory</key><string>{{html .WorkingDirectory}}</string>{{end}}
 <key>KeepAlive</key><{{bool .KeepAlive}}/>
 <key>RunAtLoad</key><{{bool .RunAtLoad}}/>
+<key>SessionCreate</key><{{bool .SessionCreate}}/>
 <key>Disabled</key><false/>
 </dict>
 </plist>


### PR DESCRIPTION
Uses undocumented launchd feature to expose desktop environment to daemons run in LaunchDaemons allowing it to access Xcode, Keychain, etc.