### PR TITLE
Change escaping rules of executable paths to cope with older versions of systemd

### DIFF
--- a/service_linux.go
+++ b/service_linux.go
@@ -69,4 +69,7 @@ var tf = map[string]interface{}{
 	"cmd": func(s string) string {
 		return `"` + strings.Replace(s, `"`, `\"`, -1) + `"`
 	},
+	"cmdEscape": func(s string) string {
+		return strings.Replace(s, " ", `\x20`, -1)
+	},
 }

--- a/service_systemd_linux.go
+++ b/service_systemd_linux.go
@@ -157,12 +157,12 @@ func (s *systemd) Restart() error {
 
 const systemdScript = `[Unit]
 Description={{.Description}}
-ConditionFileIsExecutable={{.Path|cmd}}
+ConditionFileIsExecutable={{.Path|cmdEscape}}
 
 [Service]
 StartLimitInterval=5
 StartLimitBurst=10
-ExecStart={{.Path|cmd}}{{range .Arguments}} {{.|cmd}}{{end}}
+ExecStart={{.Path|cmdEscape}}{{range .Arguments}} {{.|cmd}}{{end}}
 {{if .ChRoot}}RootDirectory={{.ChRoot|cmd}}{{end}}
 {{if .WorkingDirectory}}WorkingDirectory={{.WorkingDirectory|cmd}}{{end}}
 {{if .UserName}}User={{.UserName}}{{end}}


### PR DESCRIPTION
Older versions of systemd don't support spaces in the executable path name, instead you have to escape it with \x20. This was fixed recently but there are unfortunately still plenty of folks running older versions of systemd.

http://cgit.freedesktop.org/systemd/systemd/commit/?id=c853953658