### PR TITLE
Use 'systemctl restart' when restarting instead of stop/start

### DIFF
--- a/service_systemd_linux.go
+++ b/service_systemd_linux.go
@@ -11,7 +11,6 @@ import (
 	"os/signal"
 	"syscall"
 	"text/template"
-	"time"
 )
 
 func isSystemd() bool {
@@ -147,12 +146,7 @@ func (s *systemd) Stop() error {
 }
 
 func (s *systemd) Restart() error {
-	err := s.Stop()
-	if err != nil {
-		return err
-	}
-	time.Sleep(50 * time.Millisecond)
-	return s.Start()
+	return run("systemctl", "restart", s.Name+".service")
 }
 
 const systemdScript = `[Unit]


### PR DESCRIPTION
**systemd** has a [`restart`](http://www.freedesktop.org/software/systemd/man/systemctl.html#restart%20PATTERN...) command that I think should be used for restarting a service instead of [stop/start](https://github.com/kardianos/service/blob/5ab7ce2c8f38cc0ca92d711f7c4f3ea70d347702/service_systemd_linux.go#L149).

I actually have a use case for this. I have a daemon that updates itself and calls `<daemon> restart` via [`exec.Cmd`](https://golang.org/pkg/os/exec/#Cmd). This child process needs to have a different group id so it doesn't get killed when the parent dies (after [`service.Stop()`](https://github.com/kardianos/service/blob/5ab7ce2c8f38cc0ca92d711f7c4f3ea70d347702/service_systemd_linux.go#L150)), which is accomplished with `SysProcAttr.Setpgid`. This works fine on OS X and Ubuntu, but for some reason I don't understand (see [Starting detached child process](https://groups.google.com/forum/#!topic/golang-nuts/shST-SDqIp4)) it doesn't work on CentOS. On this system the child process dies immediately after calling `service.Stop()`.

By using `systemctl restart` instead, all is well.