### PR TITLE
Improve the TestInstallRunRestartStopRemove test

### DIFF
--- a/service_systemd_linux.go
+++ b/service_systemd_linux.go
@@ -79,9 +79,9 @@ func (s *systemd) Install() error {
 
 	var to = &struct {
 		*Config
-		Path string
+		Path         string
 		ReloadSignal string
-		PIDFile string
+		PIDFile      string
 	}{
 		s.Config,
 		path,

--- a/service_test.go
+++ b/service_test.go
@@ -5,7 +5,6 @@
 package service_test
 
 import (
-	"log"
 	"testing"
 	"time"
 
@@ -23,7 +22,7 @@ func TestRunInterrupt(t *testing.T) {
 	p := &program{}
 	s, err := service.New(p, sc)
 	if err != nil {
-		log.Fatal(err)
+		t.Fatalf("New err: %s", err)
 	}
 
 	go func() {
@@ -38,9 +37,8 @@ func TestRunInterrupt(t *testing.T) {
 		}
 	}()
 
-	err = s.Run()
-	if err != nil {
-		log.Fatal(err)
+	if err = s.Run(); err != nil {
+		t.Fatalf("Run() err: %s", err)
 	}
 }
 


### PR DESCRIPTION
I found that  TestMain wasn't actually running runService() because the arguments weren't being checked properly.  This now runs the service and tests that it has been called and finished properly.  This allows TestInstallRunRestartStopRemove to pass under Windows.

However, for some reason under Windows the test times out under Appveyor so there must be a child process that fails to finish.