### PR TITLE
Add Debug() to Logger

### DIFF
--- a/console.go
+++ b/console.go
@@ -13,13 +13,14 @@ import (
 var ConsoleLogger = consoleLogger{}
 
 type consoleLogger struct {
-	info, warn, err *log.Logger
+	info, warn, err, debug *log.Logger
 }
 
 func init() {
 	ConsoleLogger.info = log.New(os.Stderr, "I: ", log.Ltime)
 	ConsoleLogger.warn = log.New(os.Stderr, "W: ", log.Ltime)
 	ConsoleLogger.err = log.New(os.Stderr, "E: ", log.Ltime)
+	ConsoleLogger.debug = log.New(os.Stderr, "D: ", log.Ltime)
 }
 
 func (c consoleLogger) Error(v ...interface{}) error {
@@ -34,6 +35,12 @@ func (c consoleLogger) Info(v ...interface{}) error {
 	c.info.Print(v...)
 	return nil
 }
+func (c consoleLogger) Debug(v ...interface{}) error {
+	if Interactive() {
+		c.debug.Print(v...)
+	}
+	return nil
+}
 func (c consoleLogger) Errorf(format string, a ...interface{}) error {
 	c.err.Printf(format, a...)
 	return nil
@@ -44,5 +51,11 @@ func (c consoleLogger) Warningf(format string, a ...interface{}) error {
 }
 func (c consoleLogger) Infof(format string, a ...interface{}) error {
 	c.info.Printf(format, a...)
+	return nil
+}
+func (c consoleLogger) Debugf(format string, a ...interface{}) error {
+	if Interactive() {
+		c.debug.Printf(format, a...)
+	}
 	return nil
 }

--- a/service.go
+++ b/service.go
@@ -365,8 +365,10 @@ type Logger interface {
 	Error(v ...interface{}) error
 	Warning(v ...interface{}) error
 	Info(v ...interface{}) error
+	Debug(v ...interface{}) error
 
 	Errorf(format string, a ...interface{}) error
 	Warningf(format string, a ...interface{}) error
 	Infof(format string, a ...interface{}) error
+	Debugf(format string, a ...interface{}) error
 }

--- a/service_unix.go
+++ b/service_unix.go
@@ -41,6 +41,10 @@ func (s sysLogger) Warning(v ...interface{}) error {
 func (s sysLogger) Info(v ...interface{}) error {
 	return s.send(s.Writer.Info(fmt.Sprint(v...)))
 }
+func (s sysLogger) Debug(v ...interface{}) error {
+	fmt.Print(v...)
+	return nil
+}
 func (s sysLogger) Errorf(format string, a ...interface{}) error {
 	return s.send(s.Writer.Err(fmt.Sprintf(format, a...)))
 }
@@ -49,6 +53,10 @@ func (s sysLogger) Warningf(format string, a ...interface{}) error {
 }
 func (s sysLogger) Infof(format string, a ...interface{}) error {
 	return s.send(s.Writer.Info(fmt.Sprintf(format, a...)))
+}
+func (s sysLogger) Debugf(format string, a ...interface{}) error {
+	fmt.Printf(format, a...)
+	return nil
 }
 
 func run(command string, arguments ...string) error {

--- a/service_windows.go
+++ b/service_windows.go
@@ -82,6 +82,11 @@ func (l WindowsLogger) Info(v ...interface{}) error {
 	return l.send(l.ev.Info(1, fmt.Sprint(v...)))
 }
 
+func (l WindowsLogger) Debug(v ...interface{}) error {
+	fmt.Print(v...)
+	return nil
+}
+
 // Errorf logs an error message.
 func (l WindowsLogger) Errorf(format string, a ...interface{}) error {
 	return l.send(l.ev.Error(3, fmt.Sprintf(format, a...)))
@@ -95,6 +100,11 @@ func (l WindowsLogger) Warningf(format string, a ...interface{}) error {
 // Infof logs an info message.
 func (l WindowsLogger) Infof(format string, a ...interface{}) error {
 	return l.send(l.ev.Info(1, fmt.Sprintf(format, a...)))
+}
+
+func (l WindowsLogger) Debugf(format string, a ...interface{}) error {
+	fmt.Printf(format, a...)
+	return nil
 }
 
 // NError logs an error message and an event ID.


### PR DESCRIPTION
Logger.Debug() only display output when running in interactive mode.
