### PR TITLE
Fix SysV pid_file to be consistent when ran from a differently named symlink

### DIFF
--- a/service_sysv_linux.go
+++ b/service_sysv_linux.go
@@ -171,7 +171,7 @@ const sysvScript = `#!/bin/sh
 
 cmd="{{.Path}}{{range .Arguments}} {{.|cmd}}{{end}}"
 
-name=$(basename $0)
+name=$(basename $(readlink -f $0))
 pid_file="/var/run/$name.pid"
 stdout_log="/var/log/$name.log"
 stderr_log="/var/log/$name.err"


### PR DESCRIPTION
SysV init scripts are ran on boot from symlinks in `/etc/rc.d/rc.X`, where X is the runlevel. These symlinks are usually named something like `S99foobar`, which is a link to the real script `foobar`. This leads to differences in the pid_file filename and can lead to multiple processes running. By using readlink to get the actual destination filename, the pid_file name should always be consistent.

Resolves: #78