### PR TITLE
Add support for loading environment variables from optional file

### DIFF
--- a/service_systemd_linux.go
+++ b/service_systemd_linux.go
@@ -168,6 +168,7 @@ ExecStart={{.Path|cmdEscape}}{{range .Arguments}} {{.|cmd}}{{end}}
 {{if .PIDFile}}PIDFile={{.PIDFile|cmd}}{{end}}
 Restart=always
 RestartSec=120
+EnvironmentFile=-/etc/sysconfig/{{.Name}}
 
 [Install]
 WantedBy=multi-user.target

--- a/service_sysv_linux.go
+++ b/service_sysv_linux.go
@@ -176,6 +176,8 @@ pid_file="/var/run/$name.pid"
 stdout_log="/var/log/$name.log"
 stderr_log="/var/log/$name.err"
 
+[ -e /etc/sysconfig/$name ] && . /etc/sysconfig/$name
+
 get_pid() {
     cat "$pid_file"
 }


### PR DESCRIPTION
It's common to want to load environment variables from an external file for a service upon startup. The common location for these for SysV scripts is `/etc/sysconfig/$service_name`. Some examples: [docker](https://github.com/docker/docker/blob/b248de7e332b6e67b08a8981f68060e6ae629ccf/contrib/init/sysvinit-redhat/docker#L32), [Graylog](https://github.com/Graylog2/fpm-recipes/blob/debb096ffd561f72d77fd4436645429cb01baf19/recipes/graylog-server/files/rpm/init.d#L44), [nginx](https://www.nginx.com/resources/wiki/start/topics/examples/redhatnginxinit/), [elasticsearch](https://github.com/elastic/elasticsearch/blob/7560101ec73331acb39a042bde6130e59e4bb630/distribution/rpm/src/main/packaging/init.d/elasticsearch#L46-L50).

For systemd unit files, there's an option called [`EnvironmentFile`](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#EnvironmentFile=). Example: [elasticsearch](https://github.com/elastic/elasticsearch/blob/7560101ec73331acb39a042bde6130e59e4bb630/distribution/src/main/packaging/systemd/elasticsearch.service#L13).

Both of these additions are only applied if the files exist. I've tested both of them on CentOS 6 and 7, respectively. The systemd `EnvironmentFile` can always be added after the fact with a drop-in, but i added it here for consistency. If it should be excluded, I can edit the PR. For SysV scripts however, there's not really another good way to inject environment variables.