### PR TITLE
Add Upstart specific flag to handle the case of child process forks

### DIFF
--- a/service.go
+++ b/service.go
@@ -79,6 +79,9 @@ const (
 	optionRunWait      = "RunWait"
 	optionReloadSignal = "ReloadSignal"
 	optionPIDFile      = "PIDFile"
+
+	optionUpstartForksChildProcesses        = "UpstartForksChildProcesses"
+	optionUpstartForksChildProcessesDefault = false
 )
 
 // Config provides the setup for a Service. The Name field is required.
@@ -111,6 +114,7 @@ type Config struct {
 	//    - RunWait      func() (wait for SIGNAL) - Do not install signal but wait for this function to return.
 	//    - ReloadSignal string () [USR1, ...] - Signal to send on reaload.
 	//    - PIDFile     string () [/run/prog.pid] - Location of the PID file.
+	//    - UpstartForksChildProcesses bool (false) - Indicates that services forks multiple processes, executing them with wrapper script to prevent Upstart from killing child processes.
 	Option KeyValue
 }
 

--- a/service_upstart_linux.go
+++ b/service_upstart_linux.go
@@ -174,9 +174,13 @@ end script
 # Start
 {{if .UpstartForksChildProcesses }}
 script
-exec su - {{if .UserName}}{{.UserName}}{{end}} -c '{{.Path}}{{range .Arguments}} {{.|cmd}}{{end}}'
+exec su - {{if .UserName}}{{.UserName}}{{end}} -c 'set -a; test -e /etc/sysconfig/{{.Name}} && . /etc/sysconfig/{{.Name}}; {{.Path}}{{range .Arguments}} {{.|cmd}}{{end}}'
 end script
 {{else}}
-exec {{.Path}}{{range .Arguments}} {{.|cmd}}{{end}}
+script
+set -a;
+test -e /etc/sysconfig/{{.Name}} && . /etc/sysconfig/{{.Name}};
+exec {{.Path}}{{range .Arguments}} {{.|cmd}}{{end}};
+end script
 {{end}}
 `


### PR DESCRIPTION
This is a workaround to use Upstart to manage processes that spawns more than two processes and or that do not use `fork()` call.