### PR TITLE
Added support for enable/disable command for systemd service

### DIFF
--- a/service.go
+++ b/service.go
@@ -304,6 +304,10 @@ type Service interface {
 	// Install setups up the given service in the OS service manager. This may require
 	// greater rights. Will return an error if it is already installed.
 	Install() error
+    
+    
+	Enable() error
+	Disable() error
 
 	// Uninstall removes the given service from the OS service manager. This may require
 	// greater rights. Will return an error if the service is not present.
@@ -325,7 +329,7 @@ type Service interface {
 }
 
 // ControlAction list valid string texts to use in Control.
-var ControlAction = [5]string{"start", "stop", "restart", "install", "uninstall"}
+var ControlAction = [7]string{"start", "stop", "restart", "install", "uninstall","enable","disable"}
 
 // Control issues control functions to the service from a given action string.
 func Control(s Service, action string) error {
@@ -341,6 +345,10 @@ func Control(s Service, action string) error {
 		err = s.Install()
 	case ControlAction[4]:
 		err = s.Uninstall()
+	case ControlAction[5]:
+		err = s.Enable()
+	case ControlAction[6]:
+		err = s.Disable()
 	default:
 		err = fmt.Errorf("Unknown action %s", action)
 	}

--- a/service_darwin.go
+++ b/service_darwin.go
@@ -188,6 +188,13 @@ func (s *darwinLaunchdService) Restart() error {
 	return s.Start()
 }
 
+func (s *darwinLaunchdService) Enable() error {
+    return fmt.Errorf("Enable is not supported for darwin yet")
+}
+func (s *darwinLaunchdService) Disable() error {
+    return fmt.Errorf("Disable is not supported for darwin yet")
+}
+
 func (s *darwinLaunchdService) Run() error {
 	var err error
 

--- a/service_systemd_linux.go
+++ b/service_systemd_linux.go
@@ -152,6 +152,12 @@ func (s *systemd) Stop() error {
 func (s *systemd) Restart() error {
 	return run("systemctl", "restart", s.Name+".service")
 }
+func (s *systemd) Enable() error {
+	return run("systemctl", "enable", s.Name+".service")
+}
+func (s *systemd) Disable() error {
+	return run("systemctl", "disable", s.Name+".service")
+}
 
 const systemdScript = `[Unit]
 Description={{.Description}}

--- a/service_sysv_linux.go
+++ b/service_sysv_linux.go
@@ -153,6 +153,13 @@ func (s *sysv) Restart() error {
 	return s.Start()
 }
 
+func (s *sysv) Enable() error {
+    return fmt.Errorf("Enable is not supported for sysv yet")
+}
+func (s *sysv) Disable() error {
+    return fmt.Errorf("Disable is not supported for sysv yet")
+}
+
 const sysvScript = `#!/bin/sh
 # For RedHat and cousins:
 # chkconfig: - 99 01

--- a/service_upstart_linux.go
+++ b/service_upstart_linux.go
@@ -143,6 +143,14 @@ func (s *upstart) Restart() error {
 	return s.Start()
 }
 
+
+func (s *upstart) Enable() error {
+    return fmt.Errorf("Enable is not supported for upstart yet")
+}
+func (s *upstart) Disable() error {
+    return fmt.Errorf("Disable is not supported for upstart yet")
+}
+
 // The upstart script should stop with an INT or the Go runtime will terminate
 // the program before the Stop handler can run.
 const upstartScript = `# {{.Description}}

--- a/service_windows.go
+++ b/service_windows.go
@@ -290,6 +290,13 @@ func (ws *windowsService) Start() error {
 	return s.Start()
 }
 
+func (ws *windowsService) Enable() error {
+    return fmt.Errorf("Enable is not supported for Windows yet")
+}
+func (ws *windowsService) Disable() error {
+    return fmt.Errorf("Disable is not supported for Windows yet")
+}
+
 func (ws *windowsService) Stop() error {
 	m, err := mgr.Connect()
 	if err != nil {


### PR DESCRIPTION
Hello Daniel,

Thank you for your module, i'm using it extensively :)

However I faced issue that I need to manually set service as startup, so I've added this feature to you project.
Added enable/disable commands for systemd for convenience.

Tested it on Ubuntu server. Basically diff is so simple that I didn't even bother writing tests for that.

Currently i'm not using other platforms than systemd so I've just put an error Stubs for them..

