### PR TITLE
Update linux upstart detection to support RHEL6

### DIFF
--- a/service_upstart_linux.go
+++ b/service_upstart_linux.go
@@ -17,6 +17,15 @@ func isUpstart() bool {
 	if _, err := os.Stat("/sbin/upstart-udev-bridge"); err == nil {
 		return true
 	}
+	if _, err := os.Stat("/sbin/init"); err == nil {
+		if out, err := exec.Command("/sbin/init", "--version").Output(); err == nil {
+			fmt.Println(string(out))
+			if strings.Contains(string(out),"init (upstart") {
+				fmt.Println("found")
+				return true
+			}
+		}
+	}
 	return false
 }
 

--- a/service_upstart_linux.go
+++ b/service_upstart_linux.go
@@ -19,9 +19,7 @@ func isUpstart() bool {
 	}
 	if _, err := os.Stat("/sbin/init"); err == nil {
 		if out, err := exec.Command("/sbin/init", "--version").Output(); err == nil {
-			fmt.Println(string(out))
 			if strings.Contains(string(out),"init (upstart") {
-				fmt.Println("found")
 				return true
 			}
 		}


### PR DESCRIPTION
I've added additional detection logic to the isUpstart function, that should validate the existence of upstart on a RHEL 6 system.

This Resolves #91