### PR TITLE
Conform the upstart file to systemd and sysv with syscall.SIGTERM

### DIFF
--- a/service_upstart_linux.go
+++ b/service_upstart_linux.go
@@ -5,49 +5,49 @@
 package service
 
 import (
-  "errors"
-  "fmt"
-  "os"
-  "os/exec"
-  "os/signal"
-  "strings"
-  "text/template"
-  "time"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strings"
+	"text/template"
+	"time"
 )
 
 func isUpstart() bool {
-  if _, err := os.Stat("/sbin/upstart-udev-bridge"); err == nil {
-    return true
-  }
-  if _, err := os.Stat("/sbin/init"); err == nil {
-    if out, err := exec.Command("/sbin/init", "--version").Output(); err == nil {
-      if strings.Contains(string(out), "init (upstart") {
-        return true
-      }
-    }
-  }
-  return false
+	if _, err := os.Stat("/sbin/upstart-udev-bridge"); err == nil {
+		return true
+	}
+	if _, err := os.Stat("/sbin/init"); err == nil {
+		if out, err := exec.Command("/sbin/init", "--version").Output(); err == nil {
+			if strings.Contains(string(out), "init (upstart") {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 type upstart struct {
-  i Interface
-  *Config
+	i Interface
+	*Config
 }
 
 func newUpstartService(i Interface, c *Config) (Service, error) {
-  s := &upstart{
-    i:      i,
-    Config: c,
-  }
+	s := &upstart{
+		i:      i,
+		Config: c,
+	}
 
-  return s, nil
+	return s, nil
 }
 
 func (s *upstart) String() string {
-  if len(s.DisplayName) > 0 {
-    return s.DisplayName
-  }
-  return s.Name
+	if len(s.DisplayName) > 0 {
+		return s.DisplayName
+	}
+	return s.Name
 }
 
 // Upstart has some support for user services in graphical sessions.
@@ -56,100 +56,100 @@ func (s *upstart) String() string {
 var errNoUserServiceUpstart = errors.New("User services are not supported on Upstart.")
 
 func (s *upstart) configPath() (cp string, err error) {
-  if s.Option.bool(optionUserService, optionUserServiceDefault) {
-    err = errNoUserServiceUpstart
-    return
-  }
-  cp = "/etc/init/" + s.Config.Name + ".conf"
-  return
+	if s.Option.bool(optionUserService, optionUserServiceDefault) {
+		err = errNoUserServiceUpstart
+		return
+	}
+	cp = "/etc/init/" + s.Config.Name + ".conf"
+	return
 }
 func (s *upstart) template() *template.Template {
-  return template.Must(template.New("").Funcs(tf).Parse(upstartScript))
+	return template.Must(template.New("").Funcs(tf).Parse(upstartScript))
 }
 
 func (s *upstart) Install() error {
-  confPath, err := s.configPath()
-  if err != nil {
-    return err
-  }
-  _, err = os.Stat(confPath)
-  if err == nil {
-    return fmt.Errorf("Init already exists: %s", confPath)
-  }
+	confPath, err := s.configPath()
+	if err != nil {
+		return err
+	}
+	_, err = os.Stat(confPath)
+	if err == nil {
+		return fmt.Errorf("Init already exists: %s", confPath)
+	}
 
-  f, err := os.Create(confPath)
-  if err != nil {
-    return err
-  }
-  defer f.Close()
+	f, err := os.Create(confPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
 
-  path, err := s.execPath()
-  if err != nil {
-    return err
-  }
+	path, err := s.execPath()
+	if err != nil {
+		return err
+	}
 
-  var to = &struct {
-    *Config
-    Path string
-  }{
-    s.Config,
-    path,
-  }
+	var to = &struct {
+		*Config
+		Path string
+	}{
+		s.Config,
+		path,
+	}
 
-  return s.template().Execute(f, to)
+	return s.template().Execute(f, to)
 }
 
 func (s *upstart) Uninstall() error {
-  cp, err := s.configPath()
-  if err != nil {
-    return err
-  }
-  if err := os.Remove(cp); err != nil {
-    return err
-  }
-  return nil
+	cp, err := s.configPath()
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(cp); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (s *upstart) Logger(errs chan<- error) (Logger, error) {
-  if system.Interactive() {
-    return ConsoleLogger, nil
-  }
-  return s.SystemLogger(errs)
+	if system.Interactive() {
+		return ConsoleLogger, nil
+	}
+	return s.SystemLogger(errs)
 }
 func (s *upstart) SystemLogger(errs chan<- error) (Logger, error) {
-  return newSysLogger(s.Name, errs)
+	return newSysLogger(s.Name, errs)
 }
 
 func (s *upstart) Run() (err error) {
-  err = s.i.Start(s)
-  if err != nil {
-    return err
-  }
+	err = s.i.Start(s)
+	if err != nil {
+		return err
+	}
 
-  s.Option.funcSingle(optionRunWait, func() {
-    var sigChan = make(chan os.Signal, 3)
-    signal.Notify(sigChan, syscall.SIGTERM, os.Interrupt)
-    <-sigChan
-  })()
+	s.Option.funcSingle(optionRunWait, func() {
+		var sigChan = make(chan os.Signal, 3)
+		signal.Notify(sigChan, syscall.SIGTERM, os.Interrupt)
+		<-sigChan
+	})()
 
-  return s.i.Stop(s)
+	return s.i.Stop(s)
 }
 
 func (s *upstart) Start() error {
-  return run("initctl", "start", s.Name)
+	return run("initctl", "start", s.Name)
 }
 
 func (s *upstart) Stop() error {
-  return run("initctl", "stop", s.Name)
+	return run("initctl", "stop", s.Name)
 }
 
 func (s *upstart) Restart() error {
-  err := s.Stop()
-  if err != nil {
-    return err
-  }
-  time.Sleep(50 * time.Millisecond)
-  return s.Start()
+	err := s.Stop()
+	if err != nil {
+		return err
+	}
+	time.Sleep(50 * time.Millisecond)
+	return s.Start()
 }
 
 // The upstart script should stop with an INT or the Go runtime will terminate

--- a/service_upstart_linux.go
+++ b/service_upstart_linux.go
@@ -5,49 +5,49 @@
 package service
 
 import (
-	"errors"
-	"fmt"
-	"os"
-	"os/exec"
-	"os/signal"
-	"strings"
-	"text/template"
-	"time"
+  "errors"
+  "fmt"
+  "os"
+  "os/exec"
+  "os/signal"
+  "strings"
+  "text/template"
+  "time"
 )
 
 func isUpstart() bool {
-	if _, err := os.Stat("/sbin/upstart-udev-bridge"); err == nil {
-		return true
-	}
-	if _, err := os.Stat("/sbin/init"); err == nil {
-		if out, err := exec.Command("/sbin/init", "--version").Output(); err == nil {
-			if strings.Contains(string(out), "init (upstart") {
-				return true
-			}
-		}
-	}
-	return false
+  if _, err := os.Stat("/sbin/upstart-udev-bridge"); err == nil {
+    return true
+  }
+  if _, err := os.Stat("/sbin/init"); err == nil {
+    if out, err := exec.Command("/sbin/init", "--version").Output(); err == nil {
+      if strings.Contains(string(out), "init (upstart") {
+        return true
+      }
+    }
+  }
+  return false
 }
 
 type upstart struct {
-	i Interface
-	*Config
+  i Interface
+  *Config
 }
 
 func newUpstartService(i Interface, c *Config) (Service, error) {
-	s := &upstart{
-		i:      i,
-		Config: c,
-	}
+  s := &upstart{
+    i:      i,
+    Config: c,
+  }
 
-	return s, nil
+  return s, nil
 }
 
 func (s *upstart) String() string {
-	if len(s.DisplayName) > 0 {
-		return s.DisplayName
-	}
-	return s.Name
+  if len(s.DisplayName) > 0 {
+    return s.DisplayName
+  }
+  return s.Name
 }
 
 // Upstart has some support for user services in graphical sessions.
@@ -56,100 +56,100 @@ func (s *upstart) String() string {
 var errNoUserServiceUpstart = errors.New("User services are not supported on Upstart.")
 
 func (s *upstart) configPath() (cp string, err error) {
-	if s.Option.bool(optionUserService, optionUserServiceDefault) {
-		err = errNoUserServiceUpstart
-		return
-	}
-	cp = "/etc/init/" + s.Config.Name + ".conf"
-	return
+  if s.Option.bool(optionUserService, optionUserServiceDefault) {
+    err = errNoUserServiceUpstart
+    return
+  }
+  cp = "/etc/init/" + s.Config.Name + ".conf"
+  return
 }
 func (s *upstart) template() *template.Template {
-	return template.Must(template.New("").Funcs(tf).Parse(upstartScript))
+  return template.Must(template.New("").Funcs(tf).Parse(upstartScript))
 }
 
 func (s *upstart) Install() error {
-	confPath, err := s.configPath()
-	if err != nil {
-		return err
-	}
-	_, err = os.Stat(confPath)
-	if err == nil {
-		return fmt.Errorf("Init already exists: %s", confPath)
-	}
+  confPath, err := s.configPath()
+  if err != nil {
+    return err
+  }
+  _, err = os.Stat(confPath)
+  if err == nil {
+    return fmt.Errorf("Init already exists: %s", confPath)
+  }
 
-	f, err := os.Create(confPath)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
+  f, err := os.Create(confPath)
+  if err != nil {
+    return err
+  }
+  defer f.Close()
 
-	path, err := s.execPath()
-	if err != nil {
-		return err
-	}
+  path, err := s.execPath()
+  if err != nil {
+    return err
+  }
 
-	var to = &struct {
-		*Config
-		Path string
-	}{
-		s.Config,
-		path,
-	}
+  var to = &struct {
+    *Config
+    Path string
+  }{
+    s.Config,
+    path,
+  }
 
-	return s.template().Execute(f, to)
+  return s.template().Execute(f, to)
 }
 
 func (s *upstart) Uninstall() error {
-	cp, err := s.configPath()
-	if err != nil {
-		return err
-	}
-	if err := os.Remove(cp); err != nil {
-		return err
-	}
-	return nil
+  cp, err := s.configPath()
+  if err != nil {
+    return err
+  }
+  if err := os.Remove(cp); err != nil {
+    return err
+  }
+  return nil
 }
 
 func (s *upstart) Logger(errs chan<- error) (Logger, error) {
-	if system.Interactive() {
-		return ConsoleLogger, nil
-	}
-	return s.SystemLogger(errs)
+  if system.Interactive() {
+    return ConsoleLogger, nil
+  }
+  return s.SystemLogger(errs)
 }
 func (s *upstart) SystemLogger(errs chan<- error) (Logger, error) {
-	return newSysLogger(s.Name, errs)
+  return newSysLogger(s.Name, errs)
 }
 
 func (s *upstart) Run() (err error) {
-	err = s.i.Start(s)
-	if err != nil {
-		return err
-	}
+  err = s.i.Start(s)
+  if err != nil {
+    return err
+  }
 
-	s.Option.funcSingle(optionRunWait, func() {
-		var sigChan = make(chan os.Signal, 3)
-		signal.Notify(sigChan, os.Interrupt, os.Kill)
-		<-sigChan
-	})()
+  s.Option.funcSingle(optionRunWait, func() {
+    var sigChan = make(chan os.Signal, 3)
+    signal.Notify(sigChan, syscall.SIGTERM, os.Interrupt)
+    <-sigChan
+  })()
 
-	return s.i.Stop(s)
+  return s.i.Stop(s)
 }
 
 func (s *upstart) Start() error {
-	return run("initctl", "start", s.Name)
+  return run("initctl", "start", s.Name)
 }
 
 func (s *upstart) Stop() error {
-	return run("initctl", "stop", s.Name)
+  return run("initctl", "stop", s.Name)
 }
 
 func (s *upstart) Restart() error {
-	err := s.Stop()
-	if err != nil {
-		return err
-	}
-	time.Sleep(50 * time.Millisecond)
-	return s.Start()
+  err := s.Stop()
+  if err != nil {
+    return err
+  }
+  time.Sleep(50 * time.Millisecond)
+  return s.Start()
 }
 
 // The upstart script should stop with an INT or the Go runtime will terminate


### PR DESCRIPTION
In an earlier pull request these were the signals that were looked for, looks like some how that regressed at some point.