### PR TITLE
Fix upstart service on 0.6.5 and earlier

### DIFF
--- a/service_upstart_linux.go
+++ b/service_upstart_linux.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"regexp"
+	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -63,6 +65,47 @@ func (s *upstart) configPath() (cp string, err error) {
 	cp = "/etc/init/" + s.Config.Name + ".conf"
 	return
 }
+
+func (s *upstart) hasKillStanza() bool {
+	defaultValue := true
+
+	out, err := exec.Command("/sbin/init", "--version").Output()
+	if err != nil {
+		return defaultValue
+	}
+
+	re := regexp.MustCompile(`init \(upstart (\d+.\d+.\d+)\)`)
+	matches := re.FindStringSubmatch(string(out))
+	if len(matches) != 2 {
+		return defaultValue
+	}
+
+	version := make([]int, 3)
+	for idx, vStr := range strings.Split(matches[1], ".") {
+		version[idx], err = strconv.Atoi(vStr)
+		if err != nil {
+			return defaultValue
+		}
+	}
+
+	maxVersion := []int{0, 6, 5}
+	if versionAtMost(version, maxVersion) {
+		return false
+	}
+
+	return defaultValue
+}
+
+func versionAtMost(version, max []int) bool {
+	for idx, m := range max {
+		v := version[idx]
+		if v > m {
+			return false
+		}
+	}
+	return true
+}
+
 func (s *upstart) template() *template.Template {
 	return template.Must(template.New("").Funcs(tf).Parse(upstartScript))
 }
@@ -90,10 +133,12 @@ func (s *upstart) Install() error {
 
 	var to = &struct {
 		*Config
-		Path string
+		Path          string
+		HasKillStanza bool
 	}{
 		s.Config,
 		path,
+		s.hasKillStanza(),
 	}
 
 	return s.template().Execute(f, to)
@@ -158,7 +203,7 @@ const upstartScript = `# {{.Description}}
 
 {{if .DisplayName}}description    "{{.DisplayName}}"{{end}}
 
-kill signal INT
+{{if .HasKillStanza}}kill signal INT{{end}}
 {{if .ChRoot}}chroot {{.ChRoot}}{{end}}
 {{if .WorkingDirectory}}chdir {{.WorkingDirectory}}{{end}}
 start on filesystem or runlevel [2345]


### PR DESCRIPTION
The `kill signal INT` stanza is only supported in newer upstart versions. A number of systems use upstart 0.6.5 (Amazon Linux, Ubuntu 10.04, RHEL6/CentOS6), and are unable to load the service file if this stanza is included. This patch omits that stanza on platforms running upstart <= 0.6.5.

This should address issues #54 and #96.