### PR TITLE
Support Stopping Windows Service in interactive mode from within service

### DIFF
--- a/example/stopOnErr/main.go
+++ b/example/stopOnErr/main.go
@@ -1,0 +1,83 @@
+// Copyright 2015 Daniel Theophanes.
+// Use of this source code is governed by a zlib-style
+// license that can be found in the LICENSE file.
+
+// simple does nothing except block while running the service.
+package main
+
+import (
+	"log"
+	"os"
+	"time"
+
+	"github.com/kardianos/service"
+	"github.com/pkg/errors"
+)
+
+var logger service.Logger
+
+type program struct{
+	svc service.Service
+	logger service.Logger
+}
+
+func (p *program) Start(s service.Service) error {
+	// Start should not block. Do the actual work async.
+	go p.run()
+	p.logger.Info("Started")
+	return nil
+}
+func (p *program) run() {
+	// Do work here
+	err := doSomethingBlockingWithErr()
+	if err != nil {
+		p.logger.Errorf("Err while doing something: %s", err)
+		p.svc.Stop()
+	}
+}
+
+func doSomethingBlockingWithErr() error {
+	time.Sleep(time.Second*5)
+	return errors.New("Err doing something")
+}
+
+func (p *program) Stop(s service.Service) error {
+	// Stop should not block.
+	p.logger.Info("Stopping")
+	return nil
+}
+
+func main() {
+	svcConfig := &service.Config{
+		Name:        "GoServiceExampleStopOnErr",
+		DisplayName: "Go Service Example: Stop On Error",
+		Description: "This is an example Go service that stops on error.",
+	}
+
+	prg := &program{}
+	s, err := service.New(prg, svcConfig)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if len(os.Args) > 1 {
+		err = service.Control(s, os.Args[1])
+		if err != nil {
+			log.Fatal(err)
+		}
+		return
+	}
+
+	logger, err = s.Logger(nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Set instance of service and logger
+	prg.svc = s
+	prg.logger = logger
+
+	err = s.Run()
+	if err != nil {
+		logger.Error(err)
+	}
+}

--- a/service.go
+++ b/service.go
@@ -108,9 +108,10 @@ type Config struct {
 	//    - UserService   bool (false) - Install as a current user service.
 	//    - SessionCreate bool (false) - Create a full user session.
 	//  * POSIX
-	//    - RunWait      func() (wait for SIGNAL) - Do not install signal but wait for this function to return.
 	//    - ReloadSignal string () [USR1, ...] - Signal to send on reaload.
 	//    - PIDFile     string () [/run/prog.pid] - Location of the PID file.
+	//  * WINDOWS & POSIX
+	//    - RunWait      func() (wait for SIGNAL) - Do not install signal but wait for this function to return.
 	Option KeyValue
 }
 

--- a/service_windows.go
+++ b/service_windows.go
@@ -268,26 +268,13 @@ func (ws *windowsService) Run() error {
 		return err
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	ws.cancelInterruptHandler = cancel
-	return <-ws.HandleInterrupt(ctx)
-}
-
-func (ws *windowsService) HandleInterrupt(ctx context.Context) chan error {
-	errChan := make(chan error)
-
-	go func() {
-		sigChan := make(chan os.Signal)
+	ws.Option.funcSingle(optionRunWait, func() {
+		var sigChan = make(chan os.Signal)
 		signal.Notify(sigChan, os.Interrupt, os.Kill)
-		select {
-		case <-sigChan:
-		case <-ctx.Done():
-		}
+		<-sigChan
+	})()
 
-		errChan <- ws.i.Stop(ws)
-	}()
-
-	return errChan
+	return ws.i.Stop(ws)
 }
 
 func (ws *windowsService) Start() error {


### PR DESCRIPTION
# Introduction
This change allows a window service created with this package to stop itself both while running in service mode and in interactive mode.

Issue #119 was opened on this subject, although it was closed as this was identified as a feature not yet supported. The solution proposed before closing the issue involved calling os.Exit in the Stop function when running in interactive mode. This may not be satisfying for all, as the function `service.Run`, called usually in the main function, will not return, not allowing to have a single exit point for the program (in service mode, the `Run` function returns when the service is stopped.

# Proposed changes
The changes to the code that are here proposed, only affect a service compiled for WIndows platform. The changes are made in the `(*windowsService).Run()` and `(*windowsService).Stop()` functions. Instead of a blocking wait on the interrupt signal channel, the service now also waits on a context cancellation which only happens in the Stop function whenever it is called.
A test for this feature was implemented an example showing a use-case is included.