### PR TITLE
allow setting of windows StartType and ServiceType

### DIFF
--- a/service.go
+++ b/service.go
@@ -133,6 +133,9 @@ type Config struct {
 	//    - ReloadSignal  string () [USR1, ...]     - Signal to send on reaload.
 	//    - PIDFile       string () [/run/prog.pid] - Location of the PID file.
 	//    - LogOutput     bool   (false)            - Redirect StdErr & StdOut to files.
+	//  * Windows
+	//    - StartType     int (2) - win32 CreateService dwStartType option, 2 = SERVICE_AUTO_START
+	//    - ServiceType   int (0) - win32 CreateService dwServiceType, can be used to set e.g. SERVICE_INTERACTIVE_PROCESS, SERVICE_WIN32_OWN_PROCESS etc
 	Option KeyValue
 }
 

--- a/service_windows.go
+++ b/service_windows.go
@@ -205,8 +205,9 @@ func (ws *windowsService) Install() error {
 	s, err = m.CreateService(ws.Name, exepath, mgr.Config{
 		DisplayName:      ws.DisplayName,
 		Description:      ws.Description,
-		StartType:        mgr.StartAutomatic,
+		StartType:        uint32(ws.Option.int("StartType", mgr.StartAutomatic)),
 		ServiceStartName: ws.UserName,
+		ServiceType:      uint32(ws.Option.int("ServiceType", 0)),
 		Password:         ws.Option.string("Password", ""),
 		Dependencies:     ws.Dependencies,
 	}, ws.Arguments...)


### PR DESCRIPTION
- ServiceType is necessary to create interactive services
- StartType helps with #103