### PR TITLE
Add support for retrieving service status

### DIFF
--- a/service.go
+++ b/service.go
@@ -88,20 +88,13 @@ const (
 	optionLaunchdConfig = "LaunchdConfig"
 )
 
-// Status represents service status as an interger value
-type Status int
+// Status represents service status as an byte value
+type Status byte
 
-// Status of service represented as an integer
+// Status of service represented as an byte
 const (
-	StatusNotImplemented Status = iota
-	StatusUnknown
-	StatusError
-	StatusStarting
+	StatusUnknown Status = iota // Status is unable to be determined due to an error or it was not installed.
 	StatusRunning
-	StatusPausing
-	StatusPaused
-	StatusContinuing
-	StatusStopping
 	StatusStopped
 )
 
@@ -153,6 +146,8 @@ var (
 	ErrNameFieldRequired = errors.New("Config.Name field is required.")
 	// ErrNoServiceSystemDetected is returned when no system was detected.
 	ErrNoServiceSystemDetected = errors.New("No service system detected.")
+	// ErrNotInstalled is returned when the service is not installed
+	ErrNotInstalled = errors.New("the service is not installed")
 )
 
 // New creates a new service based on a service interface and configuration.
@@ -353,7 +348,7 @@ type Service interface {
 	String() string
 
 	// Status returns the current service status.
-	Status() (Status, string, error)
+	Status() (Status, error)
 }
 
 // ControlAction list valid string texts to use in Control.

--- a/service.go
+++ b/service.go
@@ -88,6 +88,23 @@ const (
 	optionLaunchdConfig = "LaunchdConfig"
 )
 
+// Status represents service status as an interger value
+type Status int
+
+// Status of service represented as an integer
+const (
+	StatusNotImplemented Status = iota
+	StatusUnknown
+	StatusError
+	StatusStarting
+	StatusRunning
+	StatusPausing
+	StatusPaused
+	StatusContinuing
+	StatusStopping
+	StatusStopped
+)
+
 // Config provides the setup for a Service. The Name field is required.
 type Config struct {
 	Name        string   // Required name of the service. No spaces suggested.
@@ -334,6 +351,9 @@ type Service interface {
 	// String displays the name of the service. The display name if present,
 	// otherwise the name.
 	String() string
+
+	// Status returns the current service status.
+	Status() (Status, string, error)
 }
 
 // ControlAction list valid string texts to use in Control.

--- a/service.go
+++ b/service.go
@@ -149,7 +149,7 @@ var (
 )
 
 var (
-	// ErrNameFieldRequired is returned when Conifg.Name is empty.
+	// ErrNameFieldRequired is returned when Config.Name is empty.
 	ErrNameFieldRequired = errors.New("Config.Name field is required.")
 	// ErrNoServiceSystemDetected is returned when no system was detected.
 	ErrNoServiceSystemDetected = errors.New("No service system detected.")

--- a/service_darwin.go
+++ b/service_darwin.go
@@ -11,6 +11,8 @@ import (
 	"os/signal"
 	"os/user"
 	"path/filepath"
+	"regexp"
+	"strings"
 	"syscall"
 	"text/template"
 	"time"
@@ -173,6 +175,23 @@ func (s *darwinLaunchdService) Uninstall() error {
 		return err
 	}
 	return os.Remove(confPath)
+}
+
+func (s *darwinLaunchdService) Status() (Status, string, error) {
+	exitCode, out, err := runWithOutput("launchctl", "list", s.Name)
+	if exitCode == 0 && err != nil {
+		if !strings.Contains(err.Error(), "failed with stderr") {
+			return StatusError, out, err
+		}
+	}
+
+	re := regexp.MustCompile(`"PID" = ([0-9]+);`)
+	matches := re.FindStringSubmatch(out)
+	if len(matches) == 2 {
+		return StatusRunning, out, nil
+	}
+
+	return StatusUnknown, out, nil
 }
 
 func (s *darwinLaunchdService) Start() error {

--- a/service_sysv_linux.go
+++ b/service_sysv_linux.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"text/template"
 	"time"
@@ -143,21 +144,20 @@ func (s *sysv) Run() (err error) {
 	return s.i.Stop(s)
 }
 
-func (s *sysv) Status() (Status, string, error) {
+func (s *sysv) Status() (Status, error) {
 	_, out, err := runWithOutput("service", s.Name, "status")
 	if err != nil {
-		return StatusError, out, err
+		return StatusUnknown, err
 	}
 
-	if out == "Running" {
-		return StatusRunning, out, nil
+	switch {
+	case strings.HasPrefix(out, "Running"):
+		return StatusRunning, nil
+	case strings.HasPrefix(out, "Stopped"):
+		return StatusStopped, nil
+	default:
+		return StatusUnknown, ErrNotInstalled
 	}
-
-	if out == "Stopped" {
-		return StatusStopped, out, nil
-	}
-
-	return StatusUnknown, out, nil
 }
 
 func (s *sysv) Start() error {

--- a/service_sysv_linux.go
+++ b/service_sysv_linux.go
@@ -143,6 +143,23 @@ func (s *sysv) Run() (err error) {
 	return s.i.Stop(s)
 }
 
+func (s *sysv) Status() (Status, string, error) {
+	_, out, err := runWithOutput("service", s.Name, "status")
+	if err != nil {
+		return StatusError, out, err
+	}
+
+	if out == "Running" {
+		return StatusRunning, out, nil
+	}
+
+	if out == "Stopped" {
+		return StatusStopped, out, nil
+	}
+
+	return StatusUnknown, out, nil
+}
+
 func (s *sysv) Start() error {
 	return run("service", s.Name, "start")
 }

--- a/service_unix.go
+++ b/service_unix.go
@@ -8,9 +8,11 @@ package service
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log/syslog"
 	"os/exec"
+	"syscall"
 )
 
 func newSysLogger(name string, errs chan<- error) (Logger, error) {
@@ -53,20 +55,43 @@ func (s sysLogger) Infof(format string, a ...interface{}) error {
 }
 
 func run(command string, arguments ...string) error {
+	_, _, err := runCommand(command, false, arguments...)
+	return err
+}
+
+func runWithOutput(command string, arguments ...string) (int, string, error) {
+	return runCommand(command, true, arguments...)
+}
+
+func runCommand(command string, readStdout bool, arguments ...string) (int, string, error) {
 	cmd := exec.Command(command, arguments...)
+
+	var output string
+	var stdout io.ReadCloser
+	var err error
+
+	if readStdout {
+		// Connect pipe to read Stdout
+		stdout, err = cmd.StdoutPipe()
+
+		if err != nil {
+			// Failed to connect pipe
+			return 0, "", fmt.Errorf("%q failed to connect stdout pipe: %v", command, err)
+		}
+	}
 
 	// Connect pipe to read Stderr
 	stderr, err := cmd.StderrPipe()
 
 	if err != nil {
 		// Failed to connect pipe
-		return fmt.Errorf("%q failed to connect stderr pipe: %v", command, err)
+		return 0, "", fmt.Errorf("%q failed to connect stderr pipe: %v", command, err)
 	}
 
 	// Do not use cmd.Run()
 	if err := cmd.Start(); err != nil {
 		// Problem while copying stdin, stdout, or stderr
-		return fmt.Errorf("%q failed: %v", command, err)
+		return 0, "", fmt.Errorf("%q failed: %v", command, err)
 	}
 
 	// Zero exit status
@@ -75,14 +100,39 @@ func run(command string, arguments ...string) error {
 	if command == "launchctl" {
 		slurp, _ := ioutil.ReadAll(stderr)
 		if len(slurp) > 0 {
-			return fmt.Errorf("%q failed with stderr: %s", command, slurp)
+			return 0, "", fmt.Errorf("%q failed with stderr: %s", command, slurp)
+		}
+	}
+
+	if readStdout {
+		out, err := ioutil.ReadAll(stdout)
+		if err != nil {
+			return 0, "", fmt.Errorf("%q failed while attempting to read stdout: %v", command, err)
+		} else if len(out) > 0 {
+			output = string(out)
 		}
 	}
 
 	if err := cmd.Wait(); err != nil {
-		// Command didn't exit with a zero exit status.
-		return fmt.Errorf("%q failed: %v", command, err)
+		exitStatus, ok := isExitError(err)
+		if ok {
+			// Command didn't exit with a zero exit status.
+			return exitStatus, output, err
+		}
+
+		// An error occurred and there is no exit status.
+		return 0, output, fmt.Errorf("%q failed: %v", command, err)
 	}
 
-	return nil
+	return 0, output, nil
+}
+
+func isExitError(err error) (int, bool) {
+	if exiterr, ok := err.(*exec.ExitError); ok {
+		if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
+			return status.ExitStatus(), true
+		}
+	}
+
+	return 0, false
 }

--- a/service_upstart_linux.go
+++ b/service_upstart_linux.go
@@ -193,21 +193,20 @@ func (s *upstart) Run() (err error) {
 	return s.i.Stop(s)
 }
 
-func (s *upstart) Status() (Status, string, error) {
+func (s *upstart) Status() (Status, error) {
 	exitCode, out, err := runWithOutput("initctl", "status", s.Name)
 	if exitCode == 0 && err != nil {
-		return StatusError, out, err
+		return StatusUnknown, err
 	}
 
-	if strings.HasPrefix(out, fmt.Sprintf("%s start/running", s.Name)) {
-		return StatusRunning, out, nil
+	switch {
+	case strings.HasPrefix(out, fmt.Sprintf("%s start/running", s.Name)):
+		return StatusRunning, nil
+	case strings.HasPrefix(out, fmt.Sprintf("%s stop/waiting", s.Name)):
+		return StatusStopped, nil
+	default:
+		return StatusUnknown, ErrNotInstalled
 	}
-
-	if strings.HasPrefix(out, fmt.Sprintf("%s stop/waiting", s.Name)) {
-		return StatusStopped, out, nil
-	}
-
-	return StatusUnknown, out, nil
 }
 
 func (s *upstart) Start() error {

--- a/service_upstart_linux.go
+++ b/service_upstart_linux.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"os/signal"
 	"regexp"
 	"strings"
@@ -21,8 +20,8 @@ func isUpstart() bool {
 		return true
 	}
 	if _, err := os.Stat("/sbin/initctl"); err == nil {
-		if out, err := exec.Command("/sbin/initctl", "--version").Output(); err == nil {
-			if strings.Contains(string(out), "initctl (upstart") {
+		if _, out, err := runWithOutput("/sbin/initctl", "--version"); err == nil {
+			if strings.Contains(out, "initctl (upstart") {
 				return true
 			}
 		}
@@ -96,13 +95,13 @@ func (s *upstart) hasSetUIDStanza() bool {
 }
 
 func (s *upstart) getUpstartVersion() []int {
-	out, err := exec.Command("/sbin/initctl", "--version").Output()
+	_, out, err := runWithOutput("/sbin/initctl", "--version")
 	if err != nil {
 		return nil
 	}
 
 	re := regexp.MustCompile(`initctl \(upstart (\d+.\d+.\d+)\)`)
-	matches := re.FindStringSubmatch(string(out))
+	matches := re.FindStringSubmatch(out)
 	if len(matches) != 2 {
 		return nil
 	}
@@ -192,6 +191,23 @@ func (s *upstart) Run() (err error) {
 	})()
 
 	return s.i.Stop(s)
+}
+
+func (s *upstart) Status() (Status, string, error) {
+	exitCode, out, err := runWithOutput("initctl", "status", s.Name)
+	if exitCode == 0 && err != nil {
+		return StatusError, out, err
+	}
+
+	if strings.HasPrefix(out, fmt.Sprintf("%s start/running", s.Name)) {
+		return StatusRunning, out, nil
+	}
+
+	if strings.HasPrefix(out, fmt.Sprintf("%s stop/waiting", s.Name)) {
+		return StatusStopped, out, nil
+	}
+
+	return StatusUnknown, out, nil
 }
 
 func (s *upstart) Start() error {


### PR DESCRIPTION
This is a pretty naive approach to fetching service status, but systemd, upstart, sysv, launchd, and windows will all return some level of detail.

Launchd doesn't appear to give any meaningful information for services that aren't running.