### PR TITLE
Potentially resolve issue with os signals

### DIFF
--- a/service_upstart_linux.go
+++ b/service_upstart_linux.go
@@ -11,6 +11,7 @@ import (
 	"os/signal"
 	"regexp"
 	"strings"
+	"syscall"
 	"text/template"
 	"time"
 )
@@ -186,7 +187,7 @@ func (s *upstart) Run() (err error) {
 
 	s.Option.funcSingle(optionRunWait, func() {
 		var sigChan = make(chan os.Signal, 3)
-		signal.Notify(sigChan, os.Interrupt, os.Kill)
+		signal.Notify(sigChan, syscall.SIGTERM, os.Interrupt)
 		<-sigChan
 	})()
 

--- a/service_windows.go
+++ b/service_windows.go
@@ -268,7 +268,7 @@ func (ws *windowsService) Run() error {
 
 	sigChan := make(chan os.Signal)
 
-	signal.Notify(sigChan, os.Interrupt, os.Kill)
+	signal.Notify(sigChan, os.Interrupt)
 
 	<-sigChan
 

--- a/service_windows.go
+++ b/service_windows.go
@@ -311,7 +311,7 @@ func (ws *windowsService) Status() (Status, error) {
 	case svc.Stopped:
 		return StatusStopped, nil
 	default:
-		return StatusUnknown, fmt.Errorf("unknown status %s", status)
+		return StatusUnknown, fmt.Errorf("unknown status %v", status)
 	}
 }
 


### PR DESCRIPTION
os.Kill can never be caught by a process, unless i'm missing some very specific use case based on a specific OS.

I've updated upstart to also listen for SIGTERM. as far as i'm aware it's the default signal sent by upstart. This will be especially important when HasKillStanza is false

@publicarray, and @jedisct1 can you look to see if these signal changes resolve your issue with OpenBSD