### PR TITLE
Add ability for service to report the system managing the service

### DIFF
--- a/service.go
+++ b/service.go
@@ -347,9 +347,9 @@ type Service interface {
 	// otherwise the name.
 	String() string
 
-	// SystemName displays the name of the system that manages the service.
+	// Platform displays the name of the system that manages the service.
 	// In most cases this will be the same as Platform().
-	SystemName() string
+	Platform() string
 
 	// Status returns the current service status.
 	Status() (Status, error)

--- a/service.go
+++ b/service.go
@@ -348,7 +348,7 @@ type Service interface {
 	String() string
 
 	// Platform displays the name of the system that manages the service.
-	// In most cases this will be the same as Platform().
+	// In most cases this will be the same as service.Platform().
 	Platform() string
 
 	// Status returns the current service status.

--- a/service.go
+++ b/service.go
@@ -347,7 +347,8 @@ type Service interface {
 	// otherwise the name.
 	String() string
 
-	// SystemName displays the name of the system that will be used to manage the service.
+	// SystemName displays the name of the system that manages the service.
+	// In most cases this will be the same as Platform().
 	SystemName() string
 
 	// Status returns the current service status.

--- a/service.go
+++ b/service.go
@@ -347,6 +347,9 @@ type Service interface {
 	// otherwise the name.
 	String() string
 
+	// SystemName displays the name of the system that will be used to manage the service.
+	SystemName() string
+
 	// Status returns the current service status.
 	Status() (Status, error)
 }

--- a/service_darwin.go
+++ b/service_darwin.go
@@ -77,6 +77,10 @@ func (s *darwinLaunchdService) String() string {
 	return s.Name
 }
 
+func (s *darwinLaunchdService) SystemName() string {
+	return version
+}
+
 func (s *darwinLaunchdService) getHomeDir() (string, error) {
 	u, err := user.Current()
 	if err == nil {

--- a/service_darwin.go
+++ b/service_darwin.go
@@ -77,7 +77,7 @@ func (s *darwinLaunchdService) String() string {
 	return s.Name
 }
 
-func (s *darwinLaunchdService) SystemName() string {
+func (s *darwinLaunchdService) Platform() string {
 	return version
 }
 

--- a/service_linux.go
+++ b/service_linux.go
@@ -13,7 +13,7 @@ type linuxSystemService struct {
 	name        string
 	detect      func() bool
 	interactive func() bool
-	new         func(i Interface, c *Config) (Service, error)
+	new         func(i Interface, systemName string, c *Config) (Service, error)
 }
 
 func (sc linuxSystemService) String() string {
@@ -26,7 +26,7 @@ func (sc linuxSystemService) Interactive() bool {
 	return sc.interactive()
 }
 func (sc linuxSystemService) New(i Interface, c *Config) (Service, error) {
-	return sc.new(i, c)
+	return sc.new(i, sc.String(), c)
 }
 
 func init() {

--- a/service_linux.go
+++ b/service_linux.go
@@ -13,7 +13,7 @@ type linuxSystemService struct {
 	name        string
 	detect      func() bool
 	interactive func() bool
-	new         func(i Interface, systemName string, c *Config) (Service, error)
+	new         func(i Interface, platform string, c *Config) (Service, error)
 }
 
 func (sc linuxSystemService) String() string {

--- a/service_systemd_linux.go
+++ b/service_systemd_linux.go
@@ -24,16 +24,16 @@ func isSystemd() bool {
 }
 
 type systemd struct {
-	i          Interface
-	systemName string
+	i        Interface
+	platform string
 	*Config
 }
 
-func newSystemdService(i Interface, systemName string, c *Config) (Service, error) {
+func newSystemdService(i Interface, platform string, c *Config) (Service, error) {
 	s := &systemd{
-		i:          i,
-		systemName: systemName,
-		Config:     c,
+		i:        i,
+		platform: platform,
+		Config:   c,
 	}
 
 	return s, nil
@@ -46,8 +46,8 @@ func (s *systemd) String() string {
 	return s.Name
 }
 
-func (s *systemd) SystemName() string {
-	return s.systemName
+func (s *systemd) Platform() string {
+	return s.platform
 }
 
 // Systemd services should be supported, but are not currently.

--- a/service_systemd_linux.go
+++ b/service_systemd_linux.go
@@ -24,14 +24,16 @@ func isSystemd() bool {
 }
 
 type systemd struct {
-	i Interface
+	i          Interface
+	systemName string
 	*Config
 }
 
-func newSystemdService(i Interface, c *Config) (Service, error) {
+func newSystemdService(i Interface, systemName string, c *Config) (Service, error) {
 	s := &systemd{
-		i:      i,
-		Config: c,
+		i:          i,
+		systemName: systemName,
+		Config:     c,
 	}
 
 	return s, nil
@@ -42,6 +44,10 @@ func (s *systemd) String() string {
 		return s.DisplayName
 	}
 	return s.Name
+}
+
+func (s *systemd) SystemName() string {
+	return s.systemName
 }
 
 // Systemd services should be supported, but are not currently.

--- a/service_sysv_linux.go
+++ b/service_sysv_linux.go
@@ -16,14 +16,16 @@ import (
 )
 
 type sysv struct {
-	i Interface
+	i          Interface
+	systemName string
 	*Config
 }
 
-func newSystemVService(i Interface, c *Config) (Service, error) {
+func newSystemVService(i Interface, systemName string, c *Config) (Service, error) {
 	s := &sysv{
-		i:      i,
-		Config: c,
+		i:          i,
+		systemName: systemName,
+		Config:     c,
 	}
 
 	return s, nil
@@ -34,6 +36,10 @@ func (s *sysv) String() string {
 		return s.DisplayName
 	}
 	return s.Name
+}
+
+func (s *sysv) SystemName() string {
+	return s.systemName
 }
 
 var errNoUserServiceSystemV = errors.New("User services are not supported on SystemV.")

--- a/service_sysv_linux.go
+++ b/service_sysv_linux.go
@@ -16,16 +16,16 @@ import (
 )
 
 type sysv struct {
-	i          Interface
-	systemName string
+	i        Interface
+	platform string
 	*Config
 }
 
-func newSystemVService(i Interface, systemName string, c *Config) (Service, error) {
+func newSystemVService(i Interface, platform string, c *Config) (Service, error) {
 	s := &sysv{
-		i:          i,
-		systemName: systemName,
-		Config:     c,
+		i:        i,
+		platform: platform,
+		Config:   c,
 	}
 
 	return s, nil
@@ -38,8 +38,8 @@ func (s *sysv) String() string {
 	return s.Name
 }
 
-func (s *sysv) SystemName() string {
-	return s.systemName
+func (s *sysv) Platform() string {
+	return s.platform
 }
 
 var errNoUserServiceSystemV = errors.New("User services are not supported on SystemV.")

--- a/service_upstart_linux.go
+++ b/service_upstart_linux.go
@@ -31,16 +31,16 @@ func isUpstart() bool {
 }
 
 type upstart struct {
-	i          Interface
-	systemName string
+	i        Interface
+	platform string
 	*Config
 }
 
-func newUpstartService(i Interface, systemName string, c *Config) (Service, error) {
+func newUpstartService(i Interface, platform string, c *Config) (Service, error) {
 	s := &upstart{
-		i:          i,
-		systemName: systemName,
-		Config:     c,
+		i:        i,
+		platform: platform,
+		Config:   c,
 	}
 
 	return s, nil
@@ -53,8 +53,8 @@ func (s *upstart) String() string {
 	return s.Name
 }
 
-func (s *upstart) SystemName() string {
-	return s.systemName
+func (s *upstart) Platform() string {
+	return s.platform
 }
 
 // Upstart has some support for user services in graphical sessions.

--- a/service_upstart_linux.go
+++ b/service_upstart_linux.go
@@ -31,14 +31,16 @@ func isUpstart() bool {
 }
 
 type upstart struct {
-	i Interface
+	i          Interface
+	systemName string
 	*Config
 }
 
-func newUpstartService(i Interface, c *Config) (Service, error) {
+func newUpstartService(i Interface, systemName string, c *Config) (Service, error) {
 	s := &upstart{
-		i:      i,
-		Config: c,
+		i:          i,
+		systemName: systemName,
+		Config:     c,
 	}
 
 	return s, nil
@@ -49,6 +51,10 @@ func (s *upstart) String() string {
 		return s.DisplayName
 	}
 	return s.Name
+}
+
+func (s *upstart) SystemName() string {
+	return s.systemName
 }
 
 // Upstart has some support for user services in graphical sessions.

--- a/service_windows.go
+++ b/service_windows.go
@@ -144,7 +144,7 @@ func (ws *windowsService) String() string {
 	return ws.Name
 }
 
-func (ws *windowsService) SystemName() string {
+func (ws *windowsService) Platform() string {
 	return version
 }
 

--- a/service_windows.go
+++ b/service_windows.go
@@ -144,6 +144,10 @@ func (ws *windowsService) String() string {
 	return ws.Name
 }
 
+func (ws *windowsService) SystemName() string {
+	return version
+}
+
 func (ws *windowsService) setError(err error) {
 	ws.errSync.Lock()
 	defer ws.errSync.Unlock()


### PR DESCRIPTION
This will only matter in instances where you may not be using `service.New`, or `service.ChosenSystem`. This allows the service itself to report the system it was created with.