### PR TITLE
Systemd/dep

### DIFF
--- a/example/logging/main.go
+++ b/example/logging/main.go
@@ -67,6 +67,9 @@ func main() {
 		Name:        "GoServiceExampleLogging",
 		DisplayName: "Go Service Example for Logging",
 		Description: "This is an example Go service that outputs log messages.",
+		Dependencies: []string{
+			"Requires=network.target",
+			"After=network-online.target syslog.target"},
 	}
 
 	prg := &program{}

--- a/service.go
+++ b/service.go
@@ -111,7 +111,13 @@ type Config struct {
 	Executable string
 
 	// Array of service dependencies.
-	// Not yet implemented on Linux or OS X.
+	// Not yet fully implemented on Linux or OS X:
+	//  1. Support linux-systemd dependencies, just put each full line as the
+	//     element of the string array, such as
+	//     "After=network.target syslog.target"
+	//     "Requires=syslog.target"
+	//     Note, such lines will be directly appended into the [Unit] of
+	//     the generated service config file, will not check their correctness.
 	Dependencies []string
 
 	// The following fields are not supported on Windows.

--- a/service_systemd_linux.go
+++ b/service_systemd_linux.go
@@ -228,6 +228,9 @@ func (s *systemd) Restart() error {
 const systemdScript = `[Unit]
 Description={{.Description}}
 ConditionFileIsExecutable={{.Path|cmdEscape}}
+{{range .Dependencies}}
+{{.}}
+{{end}}
 
 [Service]
 StartLimitInterval=5


### PR DESCRIPTION
Bug Number - none

Root Cause
Need to support the dependency config for systemd on Linux.

Reason for Regression
    N/A

Resolution
    Support linux-systemd dependencies, just put each full line as the
    element of the string array Config.Dependencies, such as
       "After=network.target syslog.target"
       "Requires=syslog.target"
    Note, such lines will be directly appended into the [Unit] of
    the generated service config file, will not check their correctness.

GUI Changes
    No

Release Notes
    No

Unit Tests
    Tested by example/logging/GoServiceExampleLogging.service:
    The dependency is added into systemd config file as wanted, and service
    works fine with the wanted dependency settings:

    rozen@angband:~/github/service/example/logging$ sudo ./logging -service install
    rozen@angband:~/github/service/example/logging$ sudo ./logging -service start
    rozen@angband:~/github/service/example/logging$
    rozen@angband:~/github/service/example/logging$ systemctl status GoServiceExampleLogging.service
    ● GoServiceExampleLogging.service - This is an example Go service that outputs log messages.
       Loaded: loaded (/etc/systemd/system/GoServiceExampleLogging.service; enabled)
       Active: active (running) since Mon 2019-03-25 16:21:09 PDT; 10min ago
     Main PID: 12970 (logging)
       CGroup: /system.slice/GoServiceExampleLogging.service
               └─12970 /home/rozen/github/service/example/logging/logging

    rozen@angband:~/github/service/example/logging$ sudo cat /etc/systemd/system/GoServiceExampleLogging.service
    [Unit]
    Description=This is an example Go service that outputs log messages.
    ConditionFileIsExecutable=/home/rozen/github/service/example/logging/logging

    Requires=network.target
    After=network-online.target syslog.target

    [Service]
    StartLimitInterval=5
    StartLimitBurst=10
    ExecStart=/home/rozen/github/service/example/logging/logging

    Restart=always
    RestartSec=120
    EnvironmentFile=-/etc/sysconfig/GoServiceExampleLogging

    [Install]
    WantedBy=multi-user.target

Reviewers
    kardianos dev.

Files:
    service.go #edit
    ervice_systemd_linux.go #edit
    example/logging/main.go #edit