### PR TITLE
Support the systemd option setting for 'Restart' and 'SuccessExitStatus

### DIFF
--- a/example/logging/main.go
+++ b/example/logging/main.go
@@ -63,6 +63,9 @@ func main() {
 	svcFlag := flag.String("service", "", "Control the system service.")
 	flag.Parse()
 
+	options := make(service.KeyValue)
+	options["Restart"] = "on-success"
+	options["SuccessExitStatus"] = "1 2 8 SIGKILL"
 	svcConfig := &service.Config{
 		Name:        "GoServiceExampleLogging",
 		DisplayName: "Go Service Example for Logging",
@@ -70,6 +73,7 @@ func main() {
 		Dependencies: []string{
 			"Requires=network.target",
 			"After=network-online.target syslog.target"},
+		Option: options,
 	}
 
 	prg := &program{}

--- a/example/logging/main.go
+++ b/example/logging/main.go
@@ -67,6 +67,9 @@ func main() {
 		Name:        "GoServiceExampleLogging",
 		DisplayName: "Go Service Example for Logging",
 		Description: "This is an example Go service that outputs log messages.",
+		Dependencies: []string{
+			"Requires=network.target",
+			"After=network-online.target syslog.target"},
 	}
 
 	prg := &program{}

--- a/service.go
+++ b/service.go
@@ -111,7 +111,13 @@ type Config struct {
 	Executable string
 
 	// Array of service dependencies.
-	// Not yet implemented on Linux or OS X.
+	// Not yet fully implemented on Linux or OS X:
+	//  1. Support linux-systemd dependencies, just put each full line as the
+	//     element of the string array, such as
+	//     "After=network.target syslog.target"
+	//     "Requires=syslog.target"
+	//     Note, such lines will be directly appended into the [Unit] of
+	//     the generated service config file, will not check their correctness.
 	Dependencies []string
 
 	// The following fields are not supported on Windows.

--- a/service.go
+++ b/service.go
@@ -81,6 +81,9 @@ const (
 	optionRunWait      = "RunWait"
 	optionReloadSignal = "ReloadSignal"
 	optionPIDFile      = "PIDFile"
+	optionRestart      = "Restart"
+
+	optionSuccessExitStatus = "SuccessExitStatus"
 
 	optionSystemdScript = "SystemdScript"
 	optionSysvScript    = "SysvScript"
@@ -139,6 +142,9 @@ type Config struct {
 	//    - ReloadSignal  string () [USR1, ...]     - Signal to send on reaload.
 	//    - PIDFile       string () [/run/prog.pid] - Location of the PID file.
 	//    - LogOutput     bool   (false)            - Redirect StdErr & StdOut to files.
+	//    - Restart       string (always)           - How shall service be restarted.
+	//    - SuccessExitStatus string ()             - The list of exit status that shall be considered as successful,
+	//                                                in addition to the default ones.
 	Option KeyValue
 }
 

--- a/service_systemd_linux.go
+++ b/service_systemd_linux.go
@@ -228,6 +228,9 @@ func (s *systemd) Restart() error {
 const systemdScript = `[Unit]
 Description={{.Description}}
 ConditionFileIsExecutable={{.Path|cmdEscape}}
+{{range .Dependencies}}
+{{.}}
+{{end}}
 
 [Service]
 StartLimitInterval=5

--- a/service_systemd_linux.go
+++ b/service_systemd_linux.go
@@ -133,6 +133,8 @@ func (s *systemd) Install() error {
 		HasOutputFileSupport bool
 		ReloadSignal         string
 		PIDFile              string
+		Restart              string
+		SuccessExitStatus    string
 		LogOutput            bool
 	}{
 		s.Config,
@@ -140,6 +142,8 @@ func (s *systemd) Install() error {
 		s.hasOutputFileSupport(),
 		s.Option.string(optionReloadSignal, ""),
 		s.Option.string(optionPIDFile, ""),
+		s.Option.string(optionRestart, "always"),
+		s.Option.string(optionSuccessExitStatus, ""),
 		s.Option.bool(optionLogOutput, optionLogOutputDefault),
 	}
 
@@ -245,7 +249,8 @@ ExecStart={{.Path|cmdEscape}}{{range .Arguments}} {{.|cmd}}{{end}}
 StandardOutput=file:/var/log/{{.Name}}.out
 StandardError=file:/var/log/{{.Name}}.err
 {{- end}}
-Restart=always
+{{if .Restart}}Restart={{.Restart}}{{end}}
+{{if .SuccessExitStatus}}SuccessExitStatus={{.SuccessExitStatus}}{{end}}
 RestartSec=120
 EnvironmentFile=-/etc/sysconfig/{{.Name}}
 


### PR DESCRIPTION
Bug Number - none

Root Cause
Support the systemd option setting for 'Restart' and 'SuccessExitStatus

Reason for Regression
N/A

Resolution
Support the systemd option setting for 'Restart' and 'SuccessExitStatus,
just add each as a new key-value item into the Config.Option, such as
"Restart=on-success"
"SuccessExitStatus=1 2 8 SIGKILL"
Note, such options will be directly appended into the [Unit] of
the generated service config file, will not check their correctness.

GUI Changes
No

Release Notes
No

Unit Tests
Tested by example/logging/GoServiceExampleLogging.service:
The new options are added into systemd config file as wanted, and service
works as expected with the new settings:

```
rozen@angband:\~/github/service/example/logging$ go build

rozen@angband:\~/github/service/example/logging$ sudo ./logging -service install
rozen@angband:\~/github/service/example/logging$ sudo ./logging -service start

rozen@angband:\~/github/service/example/logging$ systemctl status GoServiceExampleLogging
● GoServiceExampleLogging.service - This is an example Go service that outputs log messages.
   Loaded: loaded (/etc/systemd/system/GoServiceExampleLogging.service; enabled)
   Active: active (running) since Fri 2019-05-10 10:01:24 PDT; 14s ago
 Main PID: 2442 (logging)
   CGroup: /system.slice/GoServiceExampleLogging.service
           └─2442 /home/rozen/github/service/example/logging/logging

rozen@angband:\~/github/service/example/logging$ sudo cat /etc/systemd/system/GoServiceExampleLogging.service
[Unit]
Description=This is an example Go service that outputs log messages.
ConditionFileIsExecutable=/home/rozen/github/service/example/logging/logging
Requires=network.target
After=network-online.target syslog.target

[Service]
StartLimitInterval=5
StartLimitBurst=10
ExecStart=/home/rozen/github/service/example/logging/logging

Restart=on-success
SuccessExitStatus=1 2 8 SIGKILL
RestartSec=120
EnvironmentFile=-/etc/sysconfig/GoServiceExampleLogging

[Install]
WantedBy=multi-user.target`

```
Reviewers
kardianos dev.

Files:
service.go #edit
ervice_systemd_linux.go #edit
example/logging/main.go #edit