### PR TITLE
Linux systemd: two small fixes

### DIFF
--- a/service_systemd_linux.go
+++ b/service_systemd_linux.go
@@ -228,9 +228,8 @@ func (s *systemd) Restart() error {
 const systemdScript = `[Unit]
 Description={{.Description}}
 ConditionFileIsExecutable={{.Path|cmdEscape}}
-{{range .Dependencies}}
-{{.}}
-{{end}}
+{{range $i, $dep := .Dependencies}} 
+{{$dep}} {{end}}
 
 [Service]
 StartLimitInterval=5

--- a/service_systemd_linux.go
+++ b/service_systemd_linux.go
@@ -5,6 +5,7 @@
 package service
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -19,6 +20,21 @@ import (
 func isSystemd() bool {
 	if _, err := os.Stat("/run/systemd/system"); err == nil {
 		return true
+	}
+	if _, err := os.Stat("/proc/1/comm"); err == nil {
+		filerc, err := os.Open("filename")
+		if err != nil {
+			return false
+		}
+		defer filerc.Close()
+
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(filerc)
+		contents := buf.String()
+
+		if strings.Trim(contents, " \r\n") == "systemd" {
+			return true
+		}
 	}
 	return false
 }

--- a/service_systemd_linux.go
+++ b/service_systemd_linux.go
@@ -22,7 +22,7 @@ func isSystemd() bool {
 		return true
 	}
 	if _, err := os.Stat("/proc/1/comm"); err == nil {
-		filerc, err := os.Open("filename")
+		filerc, err := os.Open("/proc/1/comm")
 		if err != nil {
 			return false
 		}


### PR DESCRIPTION
1. Fixed a bug in the config template -> dependencies should now work for systemd
2. Systemd detection now possible from inside chroot (useful for package building)