### PR TITLE
Fix the inability to start with logger in docker contianer

### DIFF
--- a/service_linux.go
+++ b/service_linux.go
@@ -63,16 +63,16 @@ func init() {
 
 func isInteractive() (bool, error) {
 	// TODO: This is not true for user services.
-	inDocker, err := isInDocker()
+	inContainer, err := isInContainer()
 	if err != nil {
 		return false, err
 	}
-	return !(os.Getppid() == 1 && !inDocker), nil
+	return os.Getppid() != 1 || inContainer, nil
 }
 
-// isInDocker checks if the service is being executed in docker or lxc
+// isInContainer checks if the service is being executed in docker or lxc
 // container.
-func isInDocker() (bool, error) {
+func isInContainer() (bool, error) {
 	const (
 		cgroupFile = "/proc/1/cgroup" // cgroup file to scan
 		maxlines   = 5                // maximum lines to scan


### PR DESCRIPTION
This PR addresses issue #177 

What's done:
* function `isInContainer()`  checks if we're executing inside docker/lxc container.
* `isInteractive()` returns true if isInContainer is true even if the parent pid == 1

