### PR TITLE
bugfix(unix): Check for and ignore "Operating in progress"

### DIFF
--- a/service_unix.go
+++ b/service_unix.go
@@ -7,6 +7,7 @@
 package service
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -99,7 +100,7 @@ func runCommand(command string, readStdout bool, arguments ...string) (int, stri
 	// so check for emtpy stderr
 	if command == "launchctl" {
 		slurp, _ := ioutil.ReadAll(stderr)
-		if len(slurp) > 0 {
+		if len(slurp) > 0 && !bytes.HasSuffix(slurp, []byte("Operation now in progress\n")) {
 			return 0, "", fmt.Errorf("%q failed with stderr: %s", command, slurp)
 		}
 	}


### PR DESCRIPTION
Added some checking in the stderr reading of `run` in `service_unix` to
identify if the output ended with `Operation now in progress` is the
command was `launchctl`.

If the output has the suffix it is ignored and treated as a non-error,
all other standard error output is treaded as an error like normal.

Fixes: #181 