### PR TITLE
modify systemd template

### DIFF
--- a/service_systemd_linux.go
+++ b/service_systemd_linux.go
@@ -254,7 +254,7 @@ ConditionFileIsExecutable={{.Path|cmdEscape}}
 [Service]
 StartLimitInterval=5
 StartLimitBurst=10
-ExecStart=/bin/bash -c {{.Path|cmdEscape}}{{range .Arguments}} {{.|cmd}}{{end}}
+ExecStart=/bin/sh -c {{.Path|cmdEscape}}{{range .Arguments}} {{.|cmd}}{{end}}
 {{if .ChRoot}}RootDirectory={{.ChRoot|cmd}}{{end}}
 {{if .WorkingDirectory}}WorkingDirectory={{.WorkingDirectory|cmdEscape}}{{end}}
 {{if .UserName}}User={{.UserName}}{{end}}

--- a/service_systemd_linux.go
+++ b/service_systemd_linux.go
@@ -254,7 +254,7 @@ ConditionFileIsExecutable={{.Path|cmdEscape}}
 [Service]
 StartLimitInterval=5
 StartLimitBurst=10
-ExecStart={{.Path|cmdEscape}}{{range .Arguments}} {{.|cmd}}{{end}}
+ExecStart=/bin/bash -c {{.Path|cmdEscape}}{{range .Arguments}} {{.|cmd}}{{end}}
 {{if .ChRoot}}RootDirectory={{.ChRoot|cmd}}{{end}}
 {{if .WorkingDirectory}}WorkingDirectory={{.WorkingDirectory|cmdEscape}}{{end}}
 {{if .UserName}}User={{.UserName}}{{end}}


### PR DESCRIPTION
Without Specify "/bin/bash -c"  to execute a command,in  some distros such as Fedora 31,systemd may not know how to do it,and will except error 203 and failed to start.