### PR TITLE
Close windows service when fetching status.

### DIFF
--- a/service_windows.go
+++ b/service_windows.go
@@ -296,6 +296,7 @@ func (ws *windowsService) Status() (Status, error) {
 		}
 		return StatusUnknown, err
 	}
+	defer s.Close()
 
 	status, err := s.Query()
 	if err != nil {


### PR DESCRIPTION
During debugging noticed a missed close after opening the service to
fetch status.