### PR TITLE
differentiate between "stop" and "shutdown"

### DIFF
--- a/example/logging/main.go
+++ b/example/logging/main.go
@@ -53,6 +53,10 @@ func (p *program) Stop(s service.Service) error {
 	return nil
 }
 
+func (p *program) Shutdown(s service.Service) error {
+	return nil
+}
+
 // Service setup.
 //   Define service config.
 //   Create the service.

--- a/example/runner/runner.go
+++ b/example/runner/runner.go
@@ -102,6 +102,9 @@ func (p *program) Stop(s service.Service) error {
 	}
 	return nil
 }
+func (p *program) Shutdown(s service.Service) error {
+	return nil
+}
 
 func getConfigPath() (string, error) {
 	fullexecpath, err := os.Executable()

--- a/example/simple/main.go
+++ b/example/simple/main.go
@@ -27,6 +27,9 @@ func (p *program) Stop(s service.Service) error {
 	// Stop should not block. Return with a few seconds.
 	return nil
 }
+func (p *program) Shutdown(s service.Service) error {
+	return nil
+}
 
 func main() {
 	svcConfig := &service.Config{

--- a/example/stopPause/main.go
+++ b/example/stopPause/main.go
@@ -31,6 +31,10 @@ func (p *program) Stop(s service.Service) error {
 	return nil
 }
 
+func (p *program) Shutdown(s service.Service) error {
+	return nil
+}
+
 func main() {
 	svcConfig := &service.Config{
 		Name:        "GoServiceExampleStopPause",

--- a/service.go
+++ b/service.go
@@ -319,6 +319,11 @@ type Interface interface {
 	// It should not take more then a few seconds to execute.
 	// Stop should not call os.Exit directly in the function.
 	Stop(s Service) error
+
+	// Shutdown provides a place to clean up program execution when the system is being shutdown.
+	// It is essentially the same as Stop but for the case where machine is being shutdown/restarted
+	// instead of just normally stopping the service.
+	Shutdown(s Service) error
 }
 
 // TODO: Add Configure to Service interface.

--- a/service_test.go
+++ b/service_test.go
@@ -55,3 +55,7 @@ func (p *program) Stop(s service.Service) error {
 	p.numStopped++
 	return nil
 }
+
+func (p *program) Shutdown(s service.Service) error {
+	return nil
+}

--- a/service_windows.go
+++ b/service_windows.go
@@ -178,7 +178,14 @@ loop:
 			changes <- c.CurrentStatus
 		case svc.Stop, svc.Shutdown:
 			changes <- svc.Status{State: svc.StopPending}
-			if err := ws.i.Stop(ws); err != nil {
+			var err error
+			if c.Cmd == svc.Stop {
+				err = ws.i.Stop(ws)
+			} else {
+				err = ws.i.Shutdown(ws)
+			}
+
+			if err != nil {
 				ws.setError(err)
 				return true, 2
 			}


### PR DESCRIPTION
This allows a program to differentiate between the service stopping from a "stop" command and  the  service stopping due to system shutdown/restart.

It only works in Windows because Windows notifies services that the system is shutting down.