### PR TITLE
Fixing systemd complaint that service configurations are world-inaccessible

### DIFF
--- a/service_systemd_linux.go
+++ b/service_systemd_linux.go
@@ -132,7 +132,7 @@ func (s *systemd) Install() error {
 		return fmt.Errorf("Init already exists: %s", confPath)
 	}
 
-	f, err := os.Create(confPath)
+	f, err := os.OpenFile(confPath, os.O_WRONLY|os.O_CREATE, 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When installing a service to Linux and systemd, we're often seeing these in the system logs:

```Mar 6 08:58:13 thishostnamae systemd: Configuration file /etc/systemd/system/mydaemon.service is marked world-inaccessible. This has no effect as configuration data is accessible via APIs without restrictions. Proceeding anyway.```

This change removes these from the logs.