### PR TITLE
Shutdowner interface and Windows trigger

### DIFF
--- a/service.go
+++ b/service.go
@@ -327,7 +327,7 @@ type Shutdowner interface {
 	Interface
 	// Shutdown provides a place to clean up program execution when the system is being shutdown.
 	// It is essentially the same as Stop but for the case where machine is being shutdown/restarted
-	// instead of just normally stopping the service.
+	// instead of just normally stopping the service. Stop won't be called when Shutdown is.
 	Shutdown(s Service) error
 }
 

--- a/service.go
+++ b/service.go
@@ -321,6 +321,16 @@ type Interface interface {
 	Stop(s Service) error
 }
 
+// Shutdowner represents a service interface for a program that differentiates between "stop" and
+// "shutdown". A shutdown is triggered when the whole box (not just the service) is stopped.
+type Shutdowner interface {
+	Interface
+	// Shutdown provides a place to clean up program execution when the system is being shutdown.
+	// It is essentially the same as Stop but for the case where machine is being shutdown/restarted
+	// instead of just normally stopping the service.
+	Shutdown(s Service) error
+}
+
 // TODO: Add Configure to Service interface.
 
 // Service represents a service that can be run or controlled.

--- a/service_windows.go
+++ b/service_windows.go
@@ -176,9 +176,22 @@ loop:
 		switch c.Cmd {
 		case svc.Interrogate:
 			changes <- c.CurrentStatus
-		case svc.Stop, svc.Shutdown:
+		case svc.Stop:
 			changes <- svc.Status{State: svc.StopPending}
 			if err := ws.i.Stop(ws); err != nil {
+				ws.setError(err)
+				return true, 2
+			}
+			break loop
+		case svc.Shutdown:
+			changes <- svc.Status{State: svc.StopPending}
+			var err error
+			if wsShutdown, ok := ws.i.(Shutdowner); ok {
+				err = wsShutdown.Shutdown(ws)
+			} else {
+				err = ws.i.Stop(ws)
+			}
+			if err != nil {
 				ws.setError(err)
 				return true, 2
 			}


### PR DESCRIPTION
This PR addresses https://github.com/kardianos/service/issues/220 replacing https://github.com/kardianos/service/pull/221

Instead of polluting the whole service.Interface another interface is added and triggered from Windows implementation.