### PR TITLE
Add support of windows session change control handler

### DIFF
--- a/service.go
+++ b/service.go
@@ -80,12 +80,12 @@ const (
 	optionPrefix               = "Prefix"
 	optionPrefixDefault        = "application"
 
-	optionRunWait      = "RunWait"
-	optionReloadSignal = "ReloadSignal"
-	optionPIDFile      = "PIDFile"
+	optionRunWait            = "RunWait"
+	optionReloadSignal       = "ReloadSignal"
+	optionPIDFile            = "PIDFile"
 	optionLimitNOFILE        = "LimitNOFILE"
 	optionLimitNOFILEDefault = -1 // -1 = don't set in configuration
-	optionRestart      = "Restart"
+	optionRestart            = "Restart"
 
 	optionSuccessExitStatus = "SuccessExitStatus"
 
@@ -93,6 +93,8 @@ const (
 	optionSysvScript    = "SysvScript"
 	optionUpstartScript = "UpstartScript"
 	optionLaunchdConfig = "LaunchdConfig"
+
+	optionSessionChange = "SessionChange"
 )
 
 // Status represents service status as an byte value
@@ -237,6 +239,17 @@ func (kv KeyValue) funcSingle(name string, defaultValue func()) func() {
 		}
 	}
 	return defaultValue
+}
+
+// customHanlder returns the value of the given name, assuming the value is a func([]interface{}).
+// If the value isn't found or is not of the type, nil is returned.
+func (kv KeyValue) customHanlder(name string) func([]interface{}) {
+	if v, found := kv[name]; found {
+		if castValue, is := v.(func([]interface{})); is {
+			return castValue
+		}
+	}
+	return nil
 }
 
 // Platform returns a description of the system service.

--- a/service_windows.go
+++ b/service_windows.go
@@ -12,7 +12,9 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unsafe"
 
+	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/registry"
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/eventlog"
@@ -161,7 +163,7 @@ func (ws *windowsService) getError() error {
 }
 
 func (ws *windowsService) Execute(args []string, r <-chan svc.ChangeRequest, changes chan<- svc.Status) (bool, uint32) {
-	const cmdsAccepted = svc.AcceptStop | svc.AcceptShutdown
+	const cmdsAccepted = svc.AcceptStop | svc.AcceptShutdown | svc.AcceptSessionChange
 	changes <- svc.Status{State: svc.StartPending}
 
 	if err := ws.i.Start(ws); err != nil {
@@ -183,6 +185,15 @@ loop:
 				return true, 2
 			}
 			break loop
+		case svc.SessionChange:
+			sd := (*windows.WTSSESSION_NOTIFICATION)(unsafe.Pointer(c.EventData))
+			args := make([]interface{}, 2)
+			args[0] = c.EventType
+			args[1] = sd.SessionID
+			handler := ws.Config.Option.customHanlder(optionSessionChange)
+			if handler != nil {
+				handler(args)
+			}
 		default:
 			continue loop
 		}


### PR DESCRIPTION
Added AcceptSessionChange to windows service cmdsAccepted list so the SERVICE_CONTROL_SESSIONCHANGE  control code can be received/handled by windows services to manage the user logon/logoff events.