### PR TITLE
Adding grpc port option for service startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ despite the substantial differences.
 It also can be used to detect how a program is called, from an interactive
 terminal or from a service manager.
 
+An optional argument can be passed to the windows service on startup for a GRPC port and this 
+port is made available to the GRPC client. This is provided because of the limitations of providing
+the port number to a windows service and allows the GRPC channel to be created.
+
 ## BUGS
  * Dependencies field is not implemented for Linux systems and Launchd.
  * OS X when running as a UserService Interactive will not be accurate.

--- a/service_windows.go
+++ b/service_windows.go
@@ -164,6 +164,13 @@ func (ws *windowsService) Execute(args []string, r <-chan svc.ChangeRequest, cha
 	const cmdsAccepted = svc.AcceptStop | svc.AcceptShutdown
 	changes <- svc.Status{State: svc.StartPending}
 
+	if len(args) > 1 {
+		// this limits the port range to the 1 the GRPC server specifies since this is how ports are passed into
+		// services during startup call see https://github.com/hashicorp/go-plugin/blob/master/server.go#L506-L507
+		os.Setenv("PLUGIN_MIN_PORT", args[1])
+		os.Setenv("PLUGIN_MAX_PORT", args[1])
+	}
+
 	if err := ws.i.Start(ws); err != nil {
 		ws.setError(err)
 		return true, 1


### PR DESCRIPTION
With GRPC it requires a port to be passed in for clien/server interaction but windows services only allow arguments to be passed in during service startup, this allows for an optional parameter of the prt to be passed in