### PR TITLE
chore: Add explicit AIX tag to AIX specific sources

### DIFF
--- a/service_aix.go
+++ b/service_aix.go
@@ -1,3 +1,5 @@
+//+build aix
+
 // Copyright 2015 Daniel Theophanes.
 // Use of this source code is governed by a zlib-style
 // license that can be found in the LICENSE file.


### PR DESCRIPTION
Add an explicit AIX build restriction to the AIX specific source
files to allow Go versions <1.12 to compile the module.