### PR TITLE
Propagate windows service start parameters

### DIFF
--- a/service.go
+++ b/service.go
@@ -384,6 +384,9 @@ type Service interface {
 
 	// Status returns the current service status.
 	Status() (Status, error)
+
+	// Any runtime args
+	Args() []string
 }
 
 // ControlAction list valid string texts to use in Control.

--- a/service_aix.go
+++ b/service_aix.go
@@ -95,6 +95,10 @@ func (s *aixService) Platform() string {
 	return version
 }
 
+func (s *aixService) Args() []string {
+	return s.Config.Arguments
+}
+
 func (s *aixService) template() *template.Template {
 	functions := template.FuncMap{
 		"bool": func(v bool) string {

--- a/service_darwin.go
+++ b/service_darwin.go
@@ -81,6 +81,10 @@ func (s *darwinLaunchdService) Platform() string {
 	return version
 }
 
+func (s *darwinLaunchdService) Args() []string {
+	return s.Config.Arguments
+}
+
 func (s *darwinLaunchdService) getHomeDir() (string, error) {
 	u, err := user.Current()
 	if err == nil {

--- a/service_freebsd.go
+++ b/service_freebsd.go
@@ -68,6 +68,10 @@ func (s *freebsdService) Platform() string {
 	return version
 }
 
+func (s *freebsdService) Args() []string {
+	return s.Config.Arguments
+}
+
 func (s *freebsdService) template() *template.Template {
 	functions := template.FuncMap{
 		"bool": func(v bool) string {

--- a/service_solaris.go
+++ b/service_solaris.go
@@ -79,6 +79,10 @@ func (s *solarisService) Platform() string {
 	return version
 }
 
+func (s *solarisService) Args() []string {
+	return s.Config.Arguments
+}
+
 func (s *solarisService) template() *template.Template {
 	functions := template.FuncMap{
 		"bool": func(v bool) string {

--- a/service_systemd_linux.go
+++ b/service_systemd_linux.go
@@ -67,6 +67,10 @@ func (s *systemd) Platform() string {
 	return s.platform
 }
 
+func (s *systemd) Args() []string {
+	return s.Config.Arguments
+}
+
 func (s *systemd) configPath() (cp string, err error) {
 	if !s.isUserService() {
 		cp = "/etc/systemd/system/" + s.Config.Name + ".service"

--- a/service_sysv_linux.go
+++ b/service_sysv_linux.go
@@ -42,6 +42,10 @@ func (s *sysv) Platform() string {
 	return s.platform
 }
 
+func (s *sysv) Args() []string {
+	return s.Config.Arguments
+}
+
 var errNoUserServiceSystemV = errors.New("User services are not supported on SystemV.")
 
 func (s *sysv) configPath() (cp string, err error) {

--- a/service_upstart_linux.go
+++ b/service_upstart_linux.go
@@ -56,6 +56,10 @@ func (s *upstart) Platform() string {
 	return s.platform
 }
 
+func (s *upstart) Args() []string {
+	return s.Config.Arguments
+}
+
 // Upstart has some support for user services in graphical sessions.
 // Due to the mix of actual support for user services over versions, just don't bother.
 // Upstart will be replaced by systemd in most cases anyway.

--- a/service_windows.go
+++ b/service_windows.go
@@ -24,7 +24,7 @@ const version = "windows-service"
 type windowsService struct {
 	i Interface
 	*Config
-
+	startArgs    []string
 	errSync      sync.Mutex
 	stopStartErr error
 }
@@ -149,6 +149,10 @@ func (ws *windowsService) Platform() string {
 	return version
 }
 
+func (ws *windowsService) Args() []string {
+	return ws.startArgs
+}
+
 func (ws *windowsService) setError(err error) {
 	ws.errSync.Lock()
 	defer ws.errSync.Unlock()
@@ -163,7 +167,7 @@ func (ws *windowsService) getError() error {
 func (ws *windowsService) Execute(args []string, r <-chan svc.ChangeRequest, changes chan<- svc.Status) (bool, uint32) {
 	const cmdsAccepted = svc.AcceptStop | svc.AcceptShutdown
 	changes <- svc.Status{State: svc.StartPending}
-
+	ws.startArgs = args
 	if err := ws.i.Start(ws); err != nil {
 		ws.setError(err)
 		return true, 1


### PR DESCRIPTION
pass service start arguments via service interface

- In windows args passed into Execute are different than os.Args()
- In other OS, returning config.Arguments that developers can augment with or without os.Args(). 

```
$ sc.exe start
DESCRIPTION:
        Starts a service running.
USAGE:
        sc <server> start [service name] <arg1> <arg2> ...
```