### PR TITLE
service(windows): add support for PreShutdown

### DIFF
--- a/service.go
+++ b/service.go
@@ -154,6 +154,7 @@ type Config struct {
 	//    - LimitNOFILE	 int - Maximum open files (ulimit -n) (https://serverfault.com/questions/628610/increasing-nproc-for-processes-launched-by-systemd-on-centos-7)
 	//  * Windows
 	//    - DelayedAutoStart  bool (false) - after booting start this service after some delay
+	//    - PreshutdownTimeout int (0)     - extend the shutdown timeout of the service (in milliseconds)
 
 	Option KeyValue
 }

--- a/service_windows.go
+++ b/service_windows.go
@@ -12,7 +12,9 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unsafe"
 
+	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/registry"
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/eventlog"
@@ -161,7 +163,7 @@ func (ws *windowsService) getError() error {
 }
 
 func (ws *windowsService) Execute(args []string, r <-chan svc.ChangeRequest, changes chan<- svc.Status) (bool, uint32) {
-	const cmdsAccepted = svc.AcceptStop | svc.AcceptShutdown
+	const cmdsAccepted = svc.AcceptStop | svc.AcceptShutdown | svc.AcceptPreShutdown
 	changes <- svc.Status{State: svc.StartPending}
 
 	if err := ws.i.Start(ws); err != nil {
@@ -176,8 +178,36 @@ loop:
 		switch c.Cmd {
 		case svc.Interrogate:
 			changes <- c.CurrentStatus
+		case svc.PreShutdown:
+			checkpoint := uint32(1)
+			changes <- svc.Status{State: svc.StopPending, WaitHint: 3000, CheckPoint: checkpoint}
+
+			errCh := make(chan error)
+			go func() {
+				if wsShutdown, ok := ws.i.(Shutdowner); ok {
+					errCh <- wsShutdown.Shutdown(ws)
+				} else {
+					errCh <- ws.i.Stop(ws)
+				}
+			}()
+
+			for {
+				select {
+				case err := <-errCh:
+					if err != nil {
+						ws.setError(err)
+						return true, 2
+					}
+					break loop
+
+				default:
+					time.Sleep(1 * time.Second)
+					checkpoint++
+					changes <- svc.Status{State: svc.StopPending, WaitHint: 3000, CheckPoint: checkpoint}
+				}
+			}
+
 		case svc.Stop:
-			changes <- svc.Status{State: svc.StopPending}
 			if err := ws.i.Stop(ws); err != nil {
 				ws.setError(err)
 				return true, 2
@@ -240,6 +270,15 @@ func (ws *windowsService) Install() error {
 			return fmt.Errorf("SetupEventLogSource() failed: %s", err)
 		}
 	}
+
+	// try to extend preshutdown time
+	if timeout := ws.Option.int("PreshutdownTimeout", 0); timeout > 0 {
+		err = windows.ChangeServiceConfig2(s.Handle, windows.SERVICE_CONFIG_PRESHUTDOWN_INFO, (*byte)(unsafe.Pointer(&timeout)))
+		if err != nil {
+			return fmt.Errorf("setting PreshutdownTimeout failed: %s", err)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This adds support for `PreShutdown` as [described here](https://docs.microsoft.com/en-us/windows/win32/services/service-control-handler-function).

This allows multiple "StopPending" state updates to let Windows know that a service is still shutting down, incrementing a "CheckPoint" to let WIndows know progress is being made. By default, this extends the timeout for stopping a service to 3 minutes.

If more than 3 minutes are required (a database that absolutely requires more time to avoid corruption, for example), the time can be additionally extended by setting the `PreshutdownTimeout` option during installation of the service.