### PR TITLE
Add documentation for platform options and expose to Godoc

### DIFF
--- a/service.go
+++ b/service.go
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 // Package service provides a simple way to create a system service.
-// Currently supports Windows, Linux/(systemd | Upstart | SysV), and OSX/Launchd.
+// Currently supports Windows, Linux/(systemd | Upstart | SysV | OpenRC), and OSX/Launchd.
 //
 // Windows controls services by setting up callbacks that is non-trivial. This
 // is very different then other systems. This package provides the same API
@@ -133,28 +133,6 @@ type Config struct {
 	ChRoot           string
 
 	// System specific options.
-	//  * OS X
-	//    - LaunchdConfig string ()      - Use custom launchd config
-	//    - KeepAlive     bool   (true)
-	//    - RunAtLoad     bool   (false)
-	//    - UserService   bool   (false) - Install as a current user service.
-	//    - SessionCreate bool   (false) - Create a full user session.
-	//  * POSIX
-	//    - SystemdScript string ()                 - Use custom systemd script
-	//    - UpstartScript string ()                 - Use custom upstart script
-	//    - SysvScript    string ()                 - Use custom sysv script
-	//    - RunWait       func() (wait for SIGNAL)  - Do not install signal but wait for this function to return.
-	//    - ReloadSignal  string () [USR1, ...]     - Signal to send on reaload.
-	//    - PIDFile       string () [/run/prog.pid] - Location of the PID file.
-	//    - LogOutput     bool   (false)            - Redirect StdErr & StandardOutPath to files.
-	//    - Restart       string (always)           - How shall service be restarted.
-	//    - SuccessExitStatus string ()             - The list of exit status that shall be considered as successful,
-	//                                                in addition to the default ones.
-	//  * Linux (systemd)
-	//    - LimitNOFILE	 int - Maximum open files (ulimit -n) (https://serverfault.com/questions/628610/increasing-nproc-for-processes-launched-by-systemd-on-centos-7)
-	//  * Windows
-	//    - DelayedAutoStart  bool (false) - after booting start this service after some delay
-
 	Option KeyValue
 }
 
@@ -168,7 +146,7 @@ var (
 	ErrNameFieldRequired = errors.New("Config.Name field is required.")
 	// ErrNoServiceSystemDetected is returned when no system was detected.
 	ErrNoServiceSystemDetected = errors.New("No service system detected.")
-	// ErrNotInstalled is returned when the service is not installed
+	// ErrNotInstalled is returned when the service is not installed.
 	ErrNotInstalled = errors.New("the service is not installed")
 )
 
@@ -183,8 +161,35 @@ func New(i Interface, c *Config) (Service, error) {
 	return system.New(i, c)
 }
 
-// KeyValue provides a list of platform specific options. See platform docs for
-// more details.
+// KeyValue provides a list of system specific options.
+//  * OS X
+//    - LaunchdConfig string ()                 - Use custom launchd config.
+//    - KeepAlive     bool   (true)             - Prevent the system from stopping the service automatically.
+//    - RunAtLoad     bool   (false)            - Run the service after its job has been loaded.
+//    - SessionCreate bool   (false)            - Create a full user session.
+//
+//  * Solaris
+//    - Prefix        string ("application")    - Service FMRI prefix.
+//
+//  * POSIX
+//    - UserService   bool   (false)            - Install as a current user service.
+//    - SystemdScript string ()                 - Use custom systemd script.
+//    - UpstartScript string ()                 - Use custom upstart script.
+//    - SysvScript    string ()                 - Use custom sysv script.
+//    - OpenRCScript  string ()                 - Use custom OpenRC script.
+//    - RunWait       func() (wait for SIGNAL)  - Do not install signal but wait for this function to return.
+//    - ReloadSignal  string () [USR1, ...]     - Signal to send on reload.
+//    - PIDFile       string () [/run/prog.pid] - Location of the PID file.
+//    - LogOutput     bool   (false)            - Redirect StdErr & StandardOutPath to files.
+//    - Restart       string (always)           - How shall service be restarted.
+//    - SuccessExitStatus string ()             - The list of exit status that shall be considered as successful,
+//                                                in addition to the default ones.
+//  * Linux (systemd)
+//    - LimitNOFILE   int    (-1)               - Maximum open files (ulimit -n)
+//                                                (https://serverfault.com/questions/628610/increasing-nproc-for-processes-launched-by-systemd-on-centos-7)
+//  * Windows
+//    - DelayedAutoStart  bool (false)          - After booting, start this service after some delay.
+//    - Password  string ()                     - Password to use when interfacing with the system service manager.
 type KeyValue map[string]interface{}
 
 // bool returns the value of the given name, assuming the value is a boolean.

--- a/version.go
+++ b/version.go
@@ -40,7 +40,7 @@ func versionCompare(v1, v2 []int) (int, error) {
 	return 0, nil
 }
 
-// parseVersion will parse any integer type version seperated by periods.
+// parseVersion will parse any integer type version separated by periods.
 // This does not fully support semver style versions.
 func parseVersion(v string) []int {
 	version := make([]int, 3)


### PR DESCRIPTION
`KeyValue`'s documentation says "See platform docs for more details.", but I didn't see any in Godoc.

When looking through the source I found a helpful table, but it was not being exposed to the documentation generator.
Some of the platform specific options were missing as well.

I moved the table so that godoc associates it with `KeyValue`, and filled in the platform blanks I found. 
(I think it's all of them, but I'm not positive)

In addition, I noticed `UserService` is checked on more platforms than just OS X. So I moved it to the POSIX section.
I considered moving some of the POSIX options out to the Linux section since they're only checked there, but figured platform support may be added for them later. So I kept them as is.

There's also some minor linter complaints addressed in the comments like adding periods, and a small spelling correction.
These can be split out or removed from the patch if desired.

This is how things are rendering for my local instance:
![2021-04-12 17 33 07 j desk top 3e276e435e75](https://user-images.githubusercontent.com/13862850/114465710-7a68b380-9bb5-11eb-83c8-ee93b4b6373b.png)


compared to the current release:
https://pkg.go.dev/github.com/kardianos/service@v1.2.0#Config
+
https://pkg.go.dev/github.com/kardianos/service@v1.2.0#KeyValue
