### PR TITLE
service(darwin): fix status regression

### DIFF
--- a/service_darwin.go
+++ b/service_darwin.go
@@ -186,7 +186,7 @@ func (s *darwinLaunchdService) Uninstall() error {
 func (s *darwinLaunchdService) Status() (Status, error) {
 	exitCode, out, err := runWithOutput("launchctl", "list", s.Name)
 	if exitCode == 0 && err != nil {
-		if !strings.Contains(err.Error(), "failed with StandardError") {
+		if !strings.Contains(err.Error(), "failed with stderr") {
 			return StatusUnknown, err
 		}
 	}


### PR DESCRIPTION
In https://github.com/kardianos/service/pull/196/files#diff-5f554888209e6e12e2ac42ca24862cf09e282924e4c31b7e15c67320ac300d7eR190

`"failed with stderr"` was replaced with `"failed with StandardError"`. However, the message received is still `failed with stderr`: https://github.com/kardianos/service/blob/master/service_unix.go#L104

On macOS, this means the `status` command fails when uninstalled, installed or stopped. The only valid state is when the service is actively running.
