### PR TITLE
added missing syscall import

### DIFF
--- a/service_windows.go
+++ b/service_windows.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"golang.org/x/sys/windows"


### PR DESCRIPTION
my apologies about this team - VSCode plugins normally auto-add the imports and it didn't run today.