### PR TITLE
fix for the openrc status func

### DIFF
--- a/service_openrc_linux.go
+++ b/service_openrc_linux.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"os/signal"
 	"regexp"
-	"strings"
 	"syscall"
 	"text/template"
 	"time"
@@ -166,19 +165,28 @@ func (s *openrc) Run() (err error) {
 }
 
 func (s *openrc) Status() (Status, error) {
+	// rc-service uses the errno library for its exit codes:
+	// errno 0 = service started
+	// errno 1 = EPERM 1 Operation not permitted
+	// errno 2 = ENOENT 2 No such file or directory
+	// errno 3 = ESRCH 3 No such process
+	// for more info, see https://man7.org/linux/man-pages/man3/errno.3.html
 	_, out, err := runWithOutput("rc-service", s.Name, "status")
 	if err != nil {
-		return StatusUnknown, err
-	}
+		exitCode := err.(*exec.ExitError).ExitCode()
 
-	switch {
-	case strings.HasPrefix(out, "Running"):
-		return StatusRunning, nil
-	case strings.HasPrefix(out, "Stopped"):
-		return StatusStopped, nil
-	default:
-		return StatusUnknown, ErrNotInstalled
+		switch {
+		case exitCode == 1:
+			return StatusUnknown, err
+		case exitCode == 2:
+			return StatusUnknown, ErrNotInstalled
+		case exitCode == 3:
+			return StatusStopped, nil
+		default:
+			return StatusUnknown, fmt.Errorf("unknown error: %v - %v", out, err)
+		}
 	}
+	return StatusRunning, nil
 }
 
 func (s *openrc) Start() error {


### PR DESCRIPTION
Signed-off-by: Karen Almog <wrd4wrd@gmail.com>

This PR fixes a bug openRC status function that wrongly reported services as "Not installed" due to string mismatch.
The PR removes excess whitespaces from the "out" string of the `rc-service status` command and also does not check the error code, due to the fact that a stopped service will return the error code 3 and will exit the status function with an "unknown error".