### PR TITLE
Fix: systemd double start/stop

### DIFF
--- a/service_systemd_linux.go
+++ b/service_systemd_linux.go
@@ -265,10 +265,24 @@ func (s *systemd) Status() (Status, error) {
 }
 
 func (s *systemd) Start() error {
+	status, err := s.Status()
+	if err != nil {
+		return err
+	}
+	if status == StatusRunning {
+		return fmt.Errorf("%s already running", s.Config.Name)
+	}
 	return s.runAction("start")
 }
 
 func (s *systemd) Stop() error {
+	status, err := s.Status()
+	if err != nil {
+		return err
+	}
+	if status == StatusStopped {
+		return fmt.Errorf("%s already stopped", s.Config.Name)
+	}
 	return s.runAction("stop")
 }
 

--- a/service_systemd_linux.go
+++ b/service_systemd_linux.go
@@ -234,7 +234,8 @@ func (s *systemd) Run() (err error) {
 }
 
 func (s *systemd) Status() (Status, error) {
-	exitCode, out, err := runWithOutput("systemctl", "is-active", s.unitName())
+	unitFile := s.unitName()
+	exitCode, out, err := runWithOutput("systemctl", "is-active", unitFile)
 	if exitCode == 0 && err != nil {
 		return StatusUnknown, err
 	}
@@ -244,7 +245,7 @@ func (s *systemd) Status() (Status, error) {
 		return StatusRunning, nil
 	case strings.HasPrefix(out, "inactive"):
 		// inactive can also mean its not installed, check unit files
-		exitCode, out, err := runWithOutput("systemctl", "list-unit-files", "-t", "service", s.unitName())
+		exitCode, out, err := runWithOutput("systemctl", "list-unit-files", "-t", "service", unitFile)
 		if exitCode == 0 && err != nil {
 			return StatusUnknown, err
 		}


### PR DESCRIPTION
On other platforms, this will return an error. For the sake of consistency we may want to do it here too. It seems like a programmer error for something like a double start or double stop to succeed with a nil error.

The `run` refacotr started in this branch and was incorporated into a separate PR: https://github.com/kardianos/service/pull/287
We can either drop it or wait for that and rebase or something.

The `unitFile` thing can also be squashed, dropped, or left as-is. It predates the other fix but isn't actually important.