### PR TITLE
Update service_windows.go to avoid "unquoted search path" windows service issue

### DIFF
--- a/service_windows.go
+++ b/service_windows.go
@@ -227,6 +227,8 @@ func (ws *windowsService) Install() error {
 	if err != nil {
 		return err
 	}
+	// add quotes to the path in order to avoid "unquoted search path" issue
+	exepath = `"`+exepath+`"`
 
 	m, err := mgr.Connect()
 	if err != nil {


### PR DESCRIPTION
wrap exepath in quotes to avoid "unquoted search path" with windows services