### PR TITLE
fix: sysv linux not support ps $pid

### DIFF
--- a/service_sysv_linux.go
+++ b/service_sysv_linux.go
@@ -213,7 +213,7 @@ get_pid() {
 }
 
 is_running() {
-    [ -f "$pid_file" ] && ps $(get_pid) > /dev/null 2>&1
+    [ -f "$pid_file" ] && cat /proc/$(get_pid)/stat > /dev/null 2>&1
 }
 
 case "$1" in


### PR DESCRIPTION
sysv linux not support ps $pid command
then it can't got correct running status
then not to stop it