### PR TITLE
Provide custom log directory for posix

### DIFF
--- a/service.go
+++ b/service.go
@@ -94,6 +94,8 @@ const (
 	optionUpstartScript = "UpstartScript"
 	optionLaunchdConfig = "LaunchdConfig"
 	optionOpenRCScript  = "OpenRCScript"
+
+	optionLogDirectory = "LogDirectory"
 )
 
 // Status represents service status as an byte value
@@ -186,6 +188,8 @@ func New(i Interface, c *Config) (Service, error) {
 //    - Restart       string (always)           - How shall service be restarted.
 //    - SuccessExitStatus string ()             - The list of exit status that shall be considered as successful,
 //                                                in addition to the default ones.
+//    - LogDirectory string(/var/log)           - The path to the log files directory
+//
 //  * Linux (systemd)
 //    - LimitNOFILE   int    (-1)               - Maximum open files (ulimit -n)
 //                                                (https://serverfault.com/questions/628610/increasing-nproc-for-processes-launched-by-systemd-on-centos-7)

--- a/service_openrc_linux.go
+++ b/service_openrc_linux.go
@@ -60,9 +60,8 @@ func (s *openrc) template() *template.Template {
 
 	if customScript != "" {
 		return template.Must(template.New("").Funcs(tf).Parse(customScript))
-	} else {
-		return template.Must(template.New("").Funcs(tf).Parse(openRCScript))
 	}
+	return template.Must(template.New("").Funcs(tf).Parse(openRCScript))
 }
 
 func newOpenRCService(i Interface, platform string, c *Config) (Service, error) {
@@ -113,10 +112,12 @@ func (s *openrc) Install() error {
 
 	var to = &struct {
 		*Config
-		Path string
+		Path         string
+		LogDirectory string
 	}{
 		s.Config,
 		path,
+		s.Option.string(optionLogDirectory, defaultLogDirectory),
 	}
 
 	err = s.template().Execute(f, to)
@@ -227,7 +228,7 @@ command={{.Path|cmdEscape}}
 command_args="{{range .Arguments}}{{.}} {{end}}"
 {{- end }}
 name=$(basename $(readlink -f $command))
-supervise_daemon_args="--stdout /var/log/${name}.log --stderr /var/log/${name}.err"
+supervise_daemon_args="--stdout {{.LogDirectory}}/${name}.log --stderr {{.LogDirectory}}/${name}.err"
 
 {{- if .Dependencies }}
 depend() {

--- a/service_systemd_linux.go
+++ b/service_systemd_linux.go
@@ -128,9 +128,8 @@ func (s *systemd) template() *template.Template {
 
 	if customScript != "" {
 		return template.Must(template.New("").Funcs(tf).Parse(customScript))
-	} else {
-		return template.Must(template.New("").Funcs(tf).Parse(systemdScript))
 	}
+	return template.Must(template.New("").Funcs(tf).Parse(systemdScript))
 }
 
 func (s *systemd) isUserService() bool {
@@ -168,6 +167,7 @@ func (s *systemd) Install() error {
 		Restart              string
 		SuccessExitStatus    string
 		LogOutput            bool
+		LogDirectory         string
 	}{
 		s.Config,
 		path,
@@ -178,6 +178,7 @@ func (s *systemd) Install() error {
 		s.Option.string(optionRestart, "always"),
 		s.Option.string(optionSuccessExitStatus, ""),
 		s.Option.bool(optionLogOutput, optionLogOutputDefault),
+		s.Option.string(optionLogDirectory, defaultLogDirectory),
 	}
 
 	err = s.template().Execute(f, to)
@@ -309,8 +310,8 @@ ExecStart={{.Path|cmdEscape}}{{range .Arguments}} {{.|cmd}}{{end}}
 {{if .ReloadSignal}}ExecReload=/bin/kill -{{.ReloadSignal}} "$MAINPID"{{end}}
 {{if .PIDFile}}PIDFile={{.PIDFile|cmd}}{{end}}
 {{if and .LogOutput .HasOutputFileSupport -}}
-StandardOutput=file:/var/log/{{.Name}}.out
-StandardError=file:/var/log/{{.Name}}.err
+StandardOutput=file:{{.LogDirectory}}/{{.Name}}.out
+StandardError=file:{{.LogDirectory}}/{{.Name}}.err
 {{- end}}
 {{if gt .LimitNOFILE -1 }}LimitNOFILE={{.LimitNOFILE}}{{end}}
 {{if .Restart}}Restart={{.Restart}}{{end}}

--- a/service_sysv_linux.go
+++ b/service_sysv_linux.go
@@ -58,9 +58,8 @@ func (s *sysv) template() *template.Template {
 
 	if customScript != "" {
 		return template.Must(template.New("").Funcs(tf).Parse(customScript))
-	} else {
-		return template.Must(template.New("").Funcs(tf).Parse(sysvScript))
 	}
+	return template.Must(template.New("").Funcs(tf).Parse(sysvScript))
 }
 
 func (s *sysv) Install() error {
@@ -86,10 +85,12 @@ func (s *sysv) Install() error {
 
 	var to = &struct {
 		*Config
-		Path string
+		Path         string
+		LogDirectory string
 	}{
 		s.Config,
 		path,
+		s.Option.string(optionLogDirectory, defaultLogDirectory),
 	}
 
 	err = s.template().Execute(f, to)
@@ -203,8 +204,8 @@ cmd="{{.Path}}{{range .Arguments}} {{.|cmd}}{{end}}"
 
 name=$(basename $(readlink -f $0))
 pid_file="/var/run/$name.pid"
-stdout_log="/var/log/$name.log"
-stderr_log="/var/log/$name.err"
+stdout_log="{{.LogDirectory}}/$name.log"
+stderr_log="{{.LogDirectory}}/$name.err"
 
 [ -e /etc/sysconfig/$name ] && . /etc/sysconfig/$name
 

--- a/service_unix.go
+++ b/service_unix.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a zlib-style
 // license that can be found in the LICENSE file.
 
+//go:build linux || darwin || solaris || aix || freebsd
 // +build linux darwin solaris aix freebsd
 
 package service
@@ -15,6 +16,8 @@ import (
 	"os/exec"
 	"syscall"
 )
+
+const defaultLogDirectory = "/var/log"
 
 func newSysLogger(name string, errs chan<- error) (Logger, error) {
 	w, err := syslog.New(syslog.LOG_INFO, name)

--- a/service_upstart_linux.go
+++ b/service_upstart_linux.go
@@ -152,12 +152,14 @@ func (s *upstart) Install() error {
 		HasKillStanza   bool
 		HasSetUIDStanza bool
 		LogOutput       bool
+		LogDirectory    string
 	}{
 		s.Config,
 		path,
 		s.hasKillStanza(),
 		s.hasSetUIDStanza(),
 		s.Option.bool(optionLogOutput, optionLogOutputDefault),
+		s.Option.string(optionLogDirectory, defaultLogDirectory),
 	}
 
 	return s.template().Execute(f, to)
@@ -254,8 +256,8 @@ end script
 # Start
 script
 	{{if .LogOutput}}
-	stdout_log="/var/log/{{.Name}}.out"
-	stderr_log="/var/log/{{.Name}}.err"
+	stdout_log="{{.LogDirectory}}/{{.Name}}.out"
+	stderr_log="{{.LogDirectory}}/{{.Name}}.err"
 	{{end}}
 	
 	if [ -f "/etc/sysconfig/{{.Name}}" ]; then


### PR DESCRIPTION
When running a service on a posix system, allow to provide a custom path for the directory holding the service log files.
The default value of the log directory is kept as before