### PR TITLE
Allow setting environment variables for services running with systemd, darwin and windows

### DIFF
--- a/service.go
+++ b/service.go
@@ -134,6 +134,8 @@ type Config struct {
 
 	// System specific options.
 	Option KeyValue
+
+	EnvVars map[string]string
 }
 
 var (

--- a/service_darwin.go
+++ b/service_darwin.go
@@ -264,6 +264,13 @@ var launchdConfig = `<?xml version='1.0' encoding='UTF-8'?>
 "http://www.apple.com/DTDs/PropertyList-1.0.dtd" >
 <plist version='1.0'>
   <dict>
+	<key>EnvironmentVariables</key>
+	<dict>
+	{{range $k, $v := .EnvVars -}}
+	<key>{{html $k}}</key>
+	<string>{{html $v}}</string>
+	{{end -}}
+	</dict>
     <key>Label</key>
     <string>{{html .Name}}</string>
     <key>ProgramArguments</key>

--- a/service_systemd_linux.go
+++ b/service_systemd_linux.go
@@ -311,6 +311,10 @@ StandardError=file:/var/log/{{.Name}}.err
 RestartSec=120
 EnvironmentFile=-/etc/sysconfig/{{.Name}}
 
+{{range $k, $v := .EnvVars -}}
+Environment={{$k}}={{$v}}
+{{end -}}
+
 [Install]
 WantedBy=multi-user.target
 `

--- a/service_windows.go
+++ b/service_windows.go
@@ -222,6 +222,27 @@ loop:
 	return false, 0
 }
 
+func (ws *windowsService) setEnvironmentVariablesInRegistry() error {
+	k, _, err := registry.CreateKey(
+		registry.LOCAL_MACHINE, `SYSTEM\CurrentControlSet\Services\`+ws.Name,
+		registry.QUERY_VALUE|registry.SET_VALUE|registry.CREATE_SUB_KEY)
+	if err != nil {
+		return fmt.Errorf("failed creating env var registry key, err = %v", err)
+	}
+	envStrings := make([]string, 0, len(ws.EnvVars))
+	for k, v := range ws.EnvVars {
+		envStrings = append(envStrings, k+"="+v)
+	}
+
+	if err := k.SetStringsValue("Environment", envStrings); err != nil {
+		return fmt.Errorf("failed setting env var registry key, err = %v", err)
+	}
+	if err := k.Close(); err != nil {
+		return fmt.Errorf("failed closing env var registry key, err = %v", err)
+	}
+	return nil
+}
+
 func (ws *windowsService) Install() error {
 	exepath, err := ws.execPath()
 	if err != nil {
@@ -233,6 +254,11 @@ func (ws *windowsService) Install() error {
 		return err
 	}
 	defer m.Disconnect()
+
+	if err := ws.setEnvironmentVariablesInRegistry(); err != nil {
+		return err
+	}
+
 	s, err := m.OpenService(ws.Name)
 	if err == nil {
 		s.Close()


### PR DESCRIPTION
For our usage of the `service` package we need services to be spawned with specific environment variables (usually when running in github actions).
This PR allows setting environment variables for services running with systemd, OSx or windows which will be loaded when the service starts