### PR TITLE
Add runit support

### DIFF
--- a/linux_test/Makefile
+++ b/linux_test/Makefile
@@ -1,5 +1,5 @@
 
-all: sysv systemd upstart openrc clean
+all: sysv systemd upstart openrc runit clean
 
 # compile `go test` binary statically
 test:
@@ -43,3 +43,12 @@ openrc: test
 	@-docker rm $(shell docker ps -l -q)
 	@-docker rmi -f service.test.openrc
 	@-rm openrc/service.test
+
+runit: test
+	@echo runit
+	@cp service.test runit/
+	@docker build -q --tag="service.test.runit" runit
+	@-docker run service.test.runit
+	@-docker rm $(shell docker ps -l -q)
+	@-docker rmi -f service.test.runit
+	@-rm runit/service.test

--- a/linux_test/runit/Dockerfile
+++ b/linux_test/runit/Dockerfile
@@ -1,0 +1,3 @@
+FROM voidlinux/voidlinux:latest
+ADD service.test /tmp/
+CMD /tmp/service.test -test.v=true

--- a/service.go
+++ b/service.go
@@ -94,6 +94,7 @@ const (
 	optionUpstartScript = "UpstartScript"
 	optionLaunchdConfig = "LaunchdConfig"
 	optionOpenRCScript  = "OpenRCScript"
+	optionRunitScript   = "RunitScript"
 
 	optionLogDirectory = "LogDirectory"
 )
@@ -166,42 +167,70 @@ func New(i Interface, c *Config) (Service, error) {
 }
 
 // KeyValue provides a list of system specific options.
-//  * OS X
-//    - LaunchdConfig string ()                 - Use custom launchd config.
-//    - KeepAlive     bool   (true)             - Prevent the system from stopping the service automatically.
-//    - RunAtLoad     bool   (false)            - Run the service after its job has been loaded.
-//    - SessionCreate bool   (false)            - Create a full user session.
 //
-//  * Solaris
-//    - Prefix        string ("application")    - Service FMRI prefix.
+//   - OS X
 //
-//  * POSIX
-//    - UserService   bool   (false)            - Install as a current user service.
-//    - SystemdScript string ()                 - Use custom systemd script.
-//    - UpstartScript string ()                 - Use custom upstart script.
-//    - SysvScript    string ()                 - Use custom sysv script.
-//    - OpenRCScript  string ()                 - Use custom OpenRC script.
-//    - RunWait       func() (wait for SIGNAL)  - Do not install signal but wait for this function to return.
-//    - ReloadSignal  string () [USR1, ...]     - Signal to send on reload.
-//    - PIDFile       string () [/run/prog.pid] - Location of the PID file.
-//    - LogOutput     bool   (false)            - Redirect StdErr & StandardOutPath to files.
-//    - Restart       string (always)           - How shall service be restarted.
-//    - SuccessExitStatus string ()             - The list of exit status that shall be considered as successful,
-//                                                in addition to the default ones.
-//    - LogDirectory string(/var/log)           - The path to the log files directory
+//   - LaunchdConfig string ()                 - Use custom launchd config.
 //
-//  * Linux (systemd)
-//    - LimitNOFILE   int    (-1)               - Maximum open files (ulimit -n)
-//                                                (https://serverfault.com/questions/628610/increasing-nproc-for-processes-launched-by-systemd-on-centos-7)
-//  * Windows
-//    - DelayedAutoStart  bool (false)                - After booting, start this service after some delay.
-//    - Password  string ()                           - Password to use when interfacing with the system service manager.
-//    - Interactive       bool (false)                - The service can interact with the desktop. (more information https://docs.microsoft.com/en-us/windows/win32/services/interactive-services)
-//    - DelayedAutoStart        bool (false)          - after booting start this service after some delay.
-//    - StartType               string ("automatic")  - Start service type. (automatic | manual | disabled)
-//    - OnFailure               string ("restart" )   - Action to perform on service failure. (restart | reboot | noaction)
-//    - OnFailureDelayDuration  string ( "1s" )       - Delay before restarting the service, time.Duration string.
-//    - OnFailureResetPeriod    int ( 10 )            - Reset period for errors, seconds.
+//   - KeepAlive     bool   (true)             - Prevent the system from stopping the service automatically.
+//
+//   - RunAtLoad     bool   (false)            - Run the service after its job has been loaded.
+//
+//   - SessionCreate bool   (false)            - Create a full user session.
+//
+//   - Solaris
+//
+//   - Prefix        string ("application")    - Service FMRI prefix.
+//
+//   - POSIX
+//
+//   - UserService   bool   (false)            - Install as a current user service.
+//
+//   - SystemdScript string ()                 - Use custom systemd script.
+//
+//   - UpstartScript string ()                 - Use custom upstart script.
+//
+//   - SysvScript    string ()                 - Use custom sysv script.
+//
+//   - OpenRCScript  string ()                 - Use custom OpenRC script.
+//
+//   - RunWait       func() (wait for SIGNAL)  - Do not install signal but wait for this function to return.
+//
+//   - ReloadSignal  string () [USR1, ...]     - Signal to send on reload.
+//
+//   - PIDFile       string () [/run/prog.pid] - Location of the PID file.
+//
+//   - LogOutput     bool   (false)            - Redirect StdErr & StandardOutPath to files.
+//
+//   - Restart       string (always)           - How shall service be restarted.
+//
+//   - SuccessExitStatus string ()             - The list of exit status that shall be considered as successful,
+//     in addition to the default ones.
+//
+//   - LogDirectory string(/var/log)           - The path to the log files directory
+//
+//   - Linux (systemd)
+//
+//   - LimitNOFILE   int    (-1)               - Maximum open files (ulimit -n)
+//     (https://serverfault.com/questions/628610/increasing-nproc-for-processes-launched-by-systemd-on-centos-7)
+//
+//   - Windows
+//
+//   - DelayedAutoStart  bool (false)                - After booting, start this service after some delay.
+//
+//   - Password  string ()                           - Password to use when interfacing with the system service manager.
+//
+//   - Interactive       bool (false)                - The service can interact with the desktop. (more information https://docs.microsoft.com/en-us/windows/win32/services/interactive-services)
+//
+//   - DelayedAutoStart        bool (false)          - after booting start this service after some delay.
+//
+//   - StartType               string ("automatic")  - Start service type. (automatic | manual | disabled)
+//
+//   - OnFailure               string ("restart" )   - Action to perform on service failure. (restart | reboot | noaction)
+//
+//   - OnFailureDelayDuration  string ( "1s" )       - Delay before restarting the service, time.Duration string.
+//
+//   - OnFailureResetPeriod    int ( 10 )            - Reset period for errors, seconds.
 type KeyValue map[string]interface{}
 
 // bool returns the value of the given name, assuming the value is a boolean.
@@ -324,16 +353,16 @@ type System interface {
 // Interface represents the service interface for a program. Start runs before
 // the hosting process is granted control and Stop runs when control is returned.
 //
-//   1. OS service manager executes user program.
-//   2. User program sees it is executed from a service manager (IsInteractive is false).
-//   3. User program calls Service.Run() which blocks.
-//   4. Interface.Start() is called and quickly returns.
-//   5. User program runs.
-//   6. OS service manager signals the user program to stop.
-//   7. Interface.Stop() is called and quickly returns.
-//      - For a successful exit, os.Exit should not be called in Interface.Stop().
-//   8. Service.Run returns.
-//   9. User program should quickly exit.
+//  1. OS service manager executes user program.
+//  2. User program sees it is executed from a service manager (IsInteractive is false).
+//  3. User program calls Service.Run() which blocks.
+//  4. Interface.Start() is called and quickly returns.
+//  5. User program runs.
+//  6. OS service manager signals the user program to stop.
+//  7. Interface.Stop() is called and quickly returns.
+//     - For a successful exit, os.Exit should not be called in Interface.Stop().
+//  8. Service.Run returns.
+//  9. User program should quickly exit.
 type Interface interface {
 	// Start provides a place to initiate the service. The service doesn't
 	// signal a completed start until after this function returns, so the

--- a/service_linux.go
+++ b/service_linux.go
@@ -71,6 +71,15 @@ func init() {
 			},
 			new: newSystemVService,
 		},
+		linuxSystemService{
+			name: "linux-runit",
+			detect: isRunit,
+			interactive: func() bool {
+				is, _ := isInteractive()
+				return is
+			}
+			new: newRunitService
+		}
 	)
 }
 

--- a/service_linux.go
+++ b/service_linux.go
@@ -72,14 +72,14 @@ func init() {
 			new: newSystemVService,
 		},
 		linuxSystemService{
-			name: "linux-runit",
+			name:   "linux-runit",
 			detect: isRunit,
 			interactive: func() bool {
 				is, _ := isInteractive()
 				return is
-			}
-			new: newRunitService
-		}
+			},
+			new: newRunitService,
+		},
 	)
 }
 

--- a/service_runit_linux.go
+++ b/service_runit_linux.go
@@ -215,6 +215,6 @@ func (r *runit) runAction(action string) error {
 }
 
 const runitScript = `#!/bin/sh
-
-exec {{.Path}} 2>&1
+[ -r conf ] && . ./conf
+exec {{.Path}} ${OPTS}
 `

--- a/service_runit_linux.go
+++ b/service_runit_linux.go
@@ -1,0 +1,120 @@
+package service
+
+func isRunit() bool {
+	// TODO:
+}
+
+type runit struct {
+	i        Interface
+	platform string
+	*Config
+}
+
+func (r *runit) String() string {
+	if len(s.DisplayName) > 0 {
+		return r.DisplayName
+	}
+	return r.Name
+}
+
+func (r *runit) Platform() string {
+	return r.platform
+}
+
+func (r *runit) template() *template.Template {
+	customScript := r.Option.string(optionRunitScript, "")
+
+	if customScript != "" {
+		return template.Must(template.New("").Funcs(tf).Parse(customScript))
+	}
+	return template.Must(template.New("").Funcs(tf).Parse(runitScript))
+}
+
+func newRunitService(i Interface, platform string, c *Config) (Service, error) {
+	s := &openrc{
+		i:        i,
+		platform: platform,
+		Config:   c,
+	}
+	return s, nil
+}
+
+func (r *runit) Install() error {
+	confPath, err := r.configPath()
+	if err != nil {
+		return err
+	}
+	_, err = os.Stat(confPath)
+	if err == nil {
+		return fmt.Errorf("Init already exists: %s", confPath)
+	}
+}
+
+func (r *runit) Uninstall() error {
+	confPath, err := r.configPath()
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(confPath); err != nil {
+		return err
+	}
+	return r.runAction("delete")
+}
+
+func (r *runit) Logger(errs chan<- error) (Logger, error) {
+	if system.Interactive() {
+		return ConsoleLogger, nil
+	}
+	return r.SystemLogger(errs)
+}
+
+func (r *runit) SystemLogger(errs chan<- error) (Logger, error) {
+	return newSysLogger(s.Name, errs)
+}
+
+func (r *runit) Run() (err error) {
+	err = r.i.Start(s)
+	if err != nil {
+		return err
+	}
+
+	r.Option.funcSingle(optionRunWait, func() {
+		var sigChan = make(chan os.Signal, 3)
+		signal.Notify(sigChan, syscall.SIGTERM, os.Interrupt)
+		<-sigChan
+	})()
+
+	return r.i.Stop(s)
+}
+
+func (r *runit) Status() (Status, error) {
+}
+
+func (r *runit) Start() error {
+	return run("sv", "up", r.Name)
+}
+
+func (r *runit) Stop() error {
+	return run("sv", "down", r.Name)
+}
+
+func (r *runit) Restart() error {
+	err := r.Stop()
+	if err != nil {
+		return err
+	}
+	time.Sleep(50 * time.Millisecond)
+	return r.Start()
+}
+
+func (r *runit) run(action string, args ...string) error {
+	return run("sv", append([]string{action}, args...)...) // FIXME:
+}
+
+func (r *runit) runAction(action string) error {
+	return r.run(action, r.Name)
+}
+
+const runitLogScript = ``
+
+const runitRunScript = ``


### PR DESCRIPTION
`runit` is a cross-platform Unix init scheme with service supervision, a replacement for [sysvinit](ftp://ftp.cistron.nl/pub/people/miquels/sysvinit/), and other init schemes. It runs on GNU/Linux, *BSD, MacOSX, Solaris, and can easily be adapted to other Unix operating systems.

It uses `sv` for service management.

This is naive implementation of basic functions, still WIP. My aim is to make it work with [VoidLinux](http://voidlinux.org), but this should also work with other OSes.