### PR TITLE
Do not create windows services with an empty environment key

### DIFF
--- a/service_windows.go
+++ b/service_windows.go
@@ -241,6 +241,10 @@ func lowPrivSvc(m *mgr.Mgr, name string) (*mgr.Service, error) {
 }
 
 func (ws *windowsService) setEnvironmentVariablesInRegistry() error {
+	if len(ws.EnvVars) == 0 {
+		return nil
+	}
+
 	k, _, err := registry.CreateKey(
 		registry.LOCAL_MACHINE, `SYSTEM\CurrentControlSet\Services\`+ws.Name,
 		registry.QUERY_VALUE|registry.SET_VALUE|registry.CREATE_SUB_KEY)


### PR DESCRIPTION
Doing so will create services that are broken and will fail when started:
`Error 87: The parameter is incorrect`

This is a regression from https://github.com/kardianos/service/pull/312