### PR TITLE
Replace deprecated IsAnInteractiveSession() call

### DIFF
--- a/service_windows.go
+++ b/service_windows.go
@@ -149,11 +149,11 @@ func (l WindowsLogger) NInfof(eventID uint32, format string, a ...interface{}) e
 var interactive = false
 
 func init() {
-	var err error
-	interactive, err = svc.IsAnInteractiveSession()
+	isService, err := svc.IsWindowsService()
 	if err != nil {
 		panic(err)
 	}
+	interactive = !isService
 }
 
 func (ws *windowsService) String() string {


### PR DESCRIPTION
Using the service manager from an remote ssh command promt fails with
`The service process could not connect to the service controller`

Thanks to the detailed analysis from @kelseyma the fix was very straight forward.
Using IsWindowsService() solved this problem for me.

The mentioned issue at https://github.com/golang/go/issues/44921 has also been fixed in the meantime, so there is no reason not to use IsWindowsService() instead.

Fixes #300