### PR TITLE
fix: use windows.UTF16PtrFromString for serviceName

### DIFF
--- a/service_windows.go
+++ b/service_windows.go
@@ -231,8 +231,13 @@ func lowPrivMgr() (*mgr.Mgr, error) {
 }
 
 func lowPrivSvc(m *mgr.Mgr, name string) (*mgr.Service, error) {
+	serviceName, err := windows.UTF16PtrFromString(name)
+	if err != nil {
+		return nil, err
+	}
+
 	h, err := windows.OpenService(
-		m.Handle, syscall.StringToUTF16Ptr(name),
+		m.Handle, serviceName,
 		windows.SERVICE_QUERY_CONFIG|windows.SERVICE_QUERY_STATUS|windows.SERVICE_START|windows.SERVICE_STOP)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
syscall.StringToUTF16Ptr is Deprecated.
Use UTF16PtrFromString instead.

see https://pkg.go.dev/syscall?GOOS=windows#StringToUTF16Ptr