### PR TITLE
fix: systemd service uninstall

### DIFF
--- a/service_systemd_linux.go
+++ b/service_systemd_linux.go
@@ -210,7 +210,7 @@ func (s *systemd) Uninstall() error {
 	if err := os.Remove(cp); err != nil {
 		return err
 	}
-	return nil
+	return s.run("daemon-reload")
 }
 
 func (s *systemd) Logger(errs chan<- error) (Logger, error) {


### PR DESCRIPTION
When uninstalling systemd service, it continues to work (restarting). Disabling service doesn't remove it from systemctl list, so reload is needed. I think this is expected behavior.