### PR TITLE
Make sure that zombie processes are cleaned up

### DIFF
--- a/service_unix.go
+++ b/service_unix.go
@@ -69,6 +69,7 @@ func runWithOutput(command string, arguments ...string) (int, string, error) {
 
 func runCommand(command string, readStdout bool, arguments ...string) (int, string, error) {
 	cmd := exec.Command(command, arguments...)
+	defer cmd.Wait()
 
 	var output string
 	var stdout io.ReadCloser


### PR DESCRIPTION
As there is a usage of `cmd.Start()` ensure that [Wait()](https://pkg.go.dev/os/exec#Cmd.Wait) will be called to clean up resources.
Currently in a running app that might poll for the status, this causes a leak.