### PR TITLE
Fix systemd service file permissions

### DIFF
--- a/service_systemd_linux.go
+++ b/service_systemd_linux.go
@@ -150,7 +150,7 @@ func (s *systemd) Install() error {
 		return fmt.Errorf("Init already exists: %s", confPath)
 	}
 
-	f, err := os.OpenFile(confPath, os.O_WRONLY|os.O_CREATE, 0644)
+	f, err := os.OpenFile(confPath, os.O_WRONLY|os.O_CREATE, 0600)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes issue where the service file is created with the wrong permissions that cause systemd to complain.

- Closes #395 