### PR TITLE
windows: reduce permission requirement to query service status / config

### DIFF
--- a/service_windows.go
+++ b/service_windows.go
@@ -240,7 +240,7 @@ func lowPrivSvc(m *mgr.Mgr, name string) (*mgr.Service, error) {
 	return &mgr.Service{Handle: h, Name: name}, nil
 }
 
-func lowPrivSvcForStatus(m *mgr.Mgr, name string) (*mgr.Service, error) {
+func lowPrivSvcForQuery(m *mgr.Mgr, name string) (*mgr.Service, error) {
 	h, err := windows.OpenService(
 		m.Handle, syscall.StringToUTF16Ptr(name),
 		windows.SERVICE_QUERY_CONFIG|windows.SERVICE_QUERY_STATUS)
@@ -420,7 +420,7 @@ func (ws *windowsService) Status() (Status, error) {
 	}
 	defer m.Disconnect()
 
-	s, err := lowPrivSvcForStatus(m, ws.Name)
+	s, err := lowPrivSvcForQuery(m, ws.Name)
 	if err != nil {
 		if errno, ok := err.(syscall.Errno); ok && errno == errnoServiceDoesNotExist {
 			return StatusUnknown, ErrNotInstalled

--- a/service_windows.go
+++ b/service_windows.go
@@ -240,6 +240,16 @@ func lowPrivSvc(m *mgr.Mgr, name string) (*mgr.Service, error) {
 	return &mgr.Service{Handle: h, Name: name}, nil
 }
 
+func lowPrivSvcForStatus(m *mgr.Mgr, name string) (*mgr.Service, error) {
+	h, err := windows.OpenService(
+		m.Handle, syscall.StringToUTF16Ptr(name),
+		windows.SERVICE_QUERY_CONFIG|windows.SERVICE_QUERY_STATUS)
+	if err != nil {
+		return nil, err
+	}
+	return &mgr.Service{Handle: h, Name: name}, nil
+}
+
 func (ws *windowsService) setEnvironmentVariablesInRegistry() error {
 	if len(ws.EnvVars) == 0 {
 		return nil
@@ -410,7 +420,7 @@ func (ws *windowsService) Status() (Status, error) {
 	}
 	defer m.Disconnect()
 
-	s, err := lowPrivSvc(m, ws.Name)
+	s, err := lowPrivSvcForStatus(m, ws.Name)
 	if err != nil {
 		if errno, ok := err.(syscall.Errno); ok && errno == errnoServiceDoesNotExist {
 			return StatusUnknown, ErrNotInstalled


### PR DESCRIPTION
In current stable version (v1.2.2), I would get "Access Denied" error when I want to query service status with this package under normal Windows user role. But I can query the same service status with "sc query" command.

I tried to create "lowPrivSvcForQuery" method to reduce the required permission to query service status.