### PR TITLE
fix(linux): isInContainer works for current docker versions

### DIFF
--- a/service_linux.go
+++ b/service_linux.go
@@ -6,6 +6,7 @@ package service
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -13,6 +14,8 @@ import (
 )
 
 var cgroupFile = "/proc/1/cgroup"
+var mountInfoFile = "/proc/self/mountinfo"
+var dockerEnvFile = "/.dockerenv"
 
 type linuxSystemService struct {
 	name        string
@@ -98,7 +101,7 @@ func binaryName(pid int) (string, error) {
 }
 
 func isInteractive() (bool, error) {
-	inContainer, err := isInContainer(cgroupFile)
+	inContainer, err := isInContainer()
 	if err != nil {
 		return false, err
 	}
@@ -118,7 +121,62 @@ func isInteractive() (bool, error) {
 
 // isInContainer checks if the service is being executed in docker or lxc
 // container.
-func isInContainer(cgroupPath string) (bool, error) {
+func isInContainer() (bool, error) {
+	inContainer, err := isInContainerDockerEnv(dockerEnvFile)
+	if err != nil {
+		return false, err
+	}
+	if inContainer {
+		return true, nil
+	}
+
+	inContainer, err = isInContainerCGroup(cgroupFile)
+	if err != nil {
+		return false, err
+	}
+	if inContainer {
+		return true, nil
+	}
+
+	return isInContainerMountInfo(mountInfoFile)
+}
+
+func isInContainerDockerEnv(filePath string) (bool, error) {
+	_, err := os.Stat(filePath)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+
+	return false, err
+}
+
+func isInContainerMountInfo(filePath string) (bool, error) {
+	const maxlines = 15 // maximum lines to scan
+	f, err := os.Open(filePath)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+	scan := bufio.NewScanner(f)
+
+	lines := 0
+	for scan.Scan() && !(lines > maxlines) {
+		if strings.Contains(scan.Text(), "/docker/containers") {
+			return true, nil
+		}
+		lines++
+	}
+	if err := scan.Err(); err != nil {
+		return false, err
+	}
+
+	return false, nil
+}
+
+func isInContainerCGroup(cgroupPath string) (bool, error) {
 	const maxlines = 5 // maximum lines to scan
 
 	f, err := os.Open(cgroupPath)

--- a/service_linux_test.go
+++ b/service_linux_test.go
@@ -36,13 +36,38 @@ func createTestCgroupFiles() (*os.File, *os.File, error) {
 	return hDockerGrp, hLinuxGrp, nil
 }
 
+// createTestMountInfoFiles creates mock files for tests
+func createTestMountInfoFiles() (*os.File, *os.File, error) {
+	// docker cgroup setup
+	hDockerGrp, err := os.CreateTemp("", "*")
+	if err != nil {
+		return nil, nil, errors.New("docker tempfile create failed")
+	}
+	_, err = hDockerGrp.Write([]byte(dockerMountInfo))
+	if err != nil {
+		return nil, nil, errors.New("docker tempfile write failed")
+	}
+
+	// linux cgroup setup
+	hLinuxGrp, err := os.CreateTemp("", "*")
+	if err != nil {
+		return nil, nil, errors.New("\"normal\" tempfile  create failed")
+	}
+	_, err = hLinuxGrp.Write([]byte(linuxMountInfo))
+	if err != nil {
+		return nil, nil, errors.New("\"normal\" tempfile write failed")
+	}
+
+	return hDockerGrp, hLinuxGrp, nil
+}
+
 // removeTestFile closes and removes the provided file
 func removeTestFile(hFile *os.File) {
 	hFile.Close()
 	os.Remove(hFile.Name())
 }
 
-func Test_isInContainer(t *testing.T) {
+func Test_isInContainerCGroup(t *testing.T) {
 
 	// setup
 	hDockerGrp, hLinuxGrp, err := createTestCgroupFiles()
@@ -57,7 +82,7 @@ func Test_isInContainer(t *testing.T) {
 
 	// TEST
 	type args struct {
-		cgroupPath string
+		filePath string
 	}
 	tests := []struct {
 		name    string
@@ -70,7 +95,75 @@ func Test_isInContainer(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := isInContainer(tt.args.cgroupPath)
+			got, err := isInContainerCGroup(tt.args.filePath)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("isInContainer() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("isInContainer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+func Test_isInContainerMountInfo(t *testing.T) {
+
+	// setup
+	hDockerGrp, hLinuxGrp, err := createTestMountInfoFiles()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		// tear down
+		removeTestFile(hDockerGrp)
+		removeTestFile(hLinuxGrp)
+	}()
+
+	// TEST
+	type args struct {
+		filePath string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		{"docker", args{hDockerGrp.Name()}, true, false},
+		{"linux", args{hLinuxGrp.Name()}, false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := isInContainerMountInfo(tt.args.filePath)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("isInContainer() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("isInContainer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_isInContainerDockerEnv(t *testing.T) {
+
+	// TEST
+	type args struct {
+		filePath string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		{"docker", args{os.TempDir()}, true, false},
+		{"linux", args{"/non_existent_file"}, false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := isInContainerDockerEnv(tt.args.filePath)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("isInContainer() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -170,4 +263,34 @@ const (
 2:cpu,cpuacct:/
 1:name=systemd:/init.scope
 0::/init.scope`
+
+	dockerMountInfo = `3860 3859 0:159 / /dev/pts rw,nosuid,noexec,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+3861 3857 0:160 / /sys ro,nosuid,nodev,noexec,relatime - sysfs sysfs ro
+3862 3861 0:29 / /sys/fs/cgroup ro,nosuid,nodev,noexec,relatime - cgroup2 cgroup rw
+3863 3859 0:156 / /dev/mqueue rw,nosuid,nodev,noexec,relatime - mqueue mqueue rw
+3864 3859 0:161 / /dev/shm rw,nosuid,nodev,noexec,relatime - tmpfs shm rw,size=65536k,inode64
+3865 3857 259:4 /var/lib/docker/volumes/345b0c4550daa5dbc7f4fa9fbd28717844e69e235f2aa014c7d24114320dd9a1/_data /opt/data rw,relatime master:1 - ext4 /dev/nvme0n1p4 rw
+3866 3857 259:4 /var/lib/docker/containers/ea4d56df6742a4940bfa0b31a4481707511f2da7b7c0708ffe901b46f461eb89/resolv.conf /etc/resolv.conf rw,relatime - ext4 /dev/nvme0n1p4 rw
+3867 3857 259:4 /var/lib/docker/containers/ea4d56df6742a4940bfa0b31a4481707511f2da7b7c0708ffe901b46f461eb89/hostname /etc/hostname rw,relatime - ext4 /dev/nvme0n1p4 rw
+3868 3857 259:4 /var/lib/docker/containers/ea4d56df6742a4940bfa0b31a4481707511f2da7b7c0708ffe901b46f461eb89/hosts /etc/hosts rw,relatime - ext4 /dev/nvme0n1p4 rw
+3776 3859 0:159 /0 /dev/console rw,nosuid,noexec,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+3777 3858 0:157 /bus /proc/bus ro,nosuid,nodev,noexec,relatime - proc proc rw
+3778 3858 0:157 /fs /proc/fs ro,nosuid,nodev,noexec,relatime - proc proc rw`
+
+	linuxMountInfo = `183 28 0:44 / /run/credentials/systemd-tmpfiles-setup.service ro,nosuid,nodev,noexec,relatime,nosymfollow shared:103 - tmpfs tmpfs rw,size=1024k,nr_inodes=1024,mode=700,inode64,noswap
+129 36 0:45 / /proc/sys/fs/binfmt_misc rw,nosuid,nodev,noexec,relatime shared:105 - binfmt_misc binfmt_misc rw
+407 28 0:48 / /run/credentials/systemd-resolved.service ro,nosuid,nodev,noexec,relatime,nosymfollow shared:107 - tmpfs tmpfs rw,size=1024k,nr_inodes=1024,mode=700,inode64,noswap
+166 30 0:60 / /var/lib/lxcfs rw,nosuid,nodev,relatime shared:329 - fuse.lxcfs lxcfs rw,user_id=0,group_id=0,allow_other
+217 28 0:67 / /run/rpc_pipefs rw,relatime shared:911 - rpc_pipefs sunrpc rw
+298 28 0:26 /snapd/ns /run/snapd/ns rw,nosuid,nodev,noexec,relatime - tmpfs tmpfs rw,size=4066576k,mode=755,inode64
+335 298 0:4 mnt:[4026533124] /run/snapd/ns/cups.mnt rw - nsfs nsfs rw
+1821 298 0:4 mnt:[4026533318] /run/snapd/ns/snapd-desktop-integration.mnt rw - nsfs nsfs rw
+169 28 0:64 / /run/user/1000 rw,nosuid,nodev,relatime shared:700 - tmpfs tmpfs rw,size=4066576k,nr_inodes=1016644,mode=700,uid=1000,gid=1000,inode64
+924 169 0:65 / /run/user/1000/doc rw,nosuid,nodev,relatime shared:794 - fuse.portal portal rw,user_id=1000,group_id=1000
+2388 169 0:71 / /run/user/1000/gvfs rw,nosuid,nodev,relatime shared:814 - fuse.gvfsd-fuse gvfsd-fuse rw,user_id=1000,group_id=1000
+2948 298 0:4 mnt:[4026534753] /run/snapd/ns/firmware-updater.mnt rw - nsfs nsfs rw
+3517 30 0:129 / /var/lib/docker/overlay2/79490de289b65b7a63e86a6ae48a8607cf251030eec80d554f99eff740ba425e/merged rw,relatime shared:834 - overlay overlay rw,lowerdir=/var/lib/docker/overlay2/l/FCSCRZU3XZN6KVYV6UA4IU6CZM:/var/lib/docker/overlay2/l/I7GRZ2AVB7NO3MPA7VF75DF25N:/var/lib/docker/overlay2/l/3PHQOMHS6SD5HZFMUUENIQXENT:/var/lib/docker/overlay2/l/YOR22M55ADQZ4GRJIW3NR4EKF3:/var/lib/docker/overlay2/l/SLIJGALM6YROVNIV62WO7HLAXT,upperdir=/var/lib/docker/overlay2/79490de289b65b7a63e86a6ae48a8607cf251030eec80d554f99eff740ba425e/diff,workdir=/var/lib/docker/overlay2/79490de289b65b7a63e86a6ae48a8607cf251030eec80d554f99eff740ba425e/work,nouserxattr
+3623 28 0:4 net:[4026537044] /run/docker/netns/e63556d83137 rw shared:1054 - nsfs nsfs rw
+3548 30 0:137 / /var/lib/docker/overlay2/5f0fd269ad76199040b9b3ca1fa13ce36f9ab6799cd4b0b5406732c2c8407ff6/merged rw,relatime shared:1074 - overlay overlay rw,lowerdir=/var/lib/docker/overlay2/l/SXPONMLN4JW3QBFQWXCZ3RHVST:/var/lib/docker/overlay2/l/LA6JENXEZAPXZZF2FP4ON5WDEA:/var/lib/docker/overlay2/l/XEGVGERQJ7L72RWT3VIXEWGBL4:/var/lib/docker/overlay2/l/BPXXR3DHMVCSQWGSXG5NFNBE5W,upperdir=/var/lib/docker/overlay2/5f0fd269ad76199040b9b3ca1fa13ce36f9ab6799cd4b0b5406732c2c8407ff6/diff,workdir=/var/lib/docker/overlay2/5f0fd269ad76199040b9b3ca1fa13ce36f9ab6799cd4b0b5406732c2c8407ff6/work,nouserxattr
+3700 28 0:4 net:[4026537144] /run/docker/netns/0b489b9c590d rw shared:1094 - nsfs nsfs rw`
 )


### PR DESCRIPTION
Current docker version can use new cgroup version and the check done by `isInContainer` works only with cgroup v1.

This PR add other checks (as suggested [here](https://www.baeldung.com/linux/is-process-running-inside-container)): 

* checks for dockerenv
* checks for mountinfo

closes #363 
 
Replace PR https://github.com/kardianos/service/pull/406