### PR TITLE
feat(systemd): add WantedBy option with default multi-user.target

### DIFF
--- a/service.go
+++ b/service.go
@@ -97,6 +97,9 @@ const (
 	optionOpenRCScript  = "OpenRCScript"
 
 	optionLogDirectory = "LogDirectory"
+
+	optionWantedBy        = "WantedBy"
+	optionWantedByDefault = "multi-user.target"
 )
 
 // Status represents service status as an byte value

--- a/service_systemd_linux.go
+++ b/service_systemd_linux.go
@@ -175,6 +175,7 @@ func (s *systemd) Install() error {
 		SuccessExitStatus    string
 		LogOutput            bool
 		LogDirectory         string
+		WantedBy             string
 	}{
 		s.Config,
 		path,
@@ -186,6 +187,7 @@ func (s *systemd) Install() error {
 		s.Option.string(optionSuccessExitStatus, ""),
 		s.Option.bool(optionLogOutput, optionLogOutputDefault),
 		s.Option.string(optionLogDirectory, defaultLogDirectory),
+		s.Option.string(optionWantedBy, optionWantedByDefault),
 	}
 
 	err = s.template().Execute(f, to)


### PR DESCRIPTION
*Background*
When installing a service as a systemd user service (with UserService option set to true), the generated unit file uses WantedBy=multi-user.target by default. However, multi-user.target does not exist in the user systemd instance, which causes the service to fail to start on user login.

*Problem*
For user services, the correct target should be default.target instead of multi-user.target. Currently, there is no way to customize the WantedBy directive without providing a complete custom systemd script template via the SystemdScript option.

*Solution*
This PR adds a new WantedBy option that allows users to specify the systemd target:

Default value: multi-user.target (backward compatible)
For user services: users can set it to default.target
```
svcConfig := &service.Config{
    Name:        "myservice",
    DisplayName: "My Service",
    Description: "My service description",
    Option: service.KeyValue{
        "UserService": true,
        "WantedBy":    "default.target",
    },
}
```